### PR TITLE
Fix empty screen on telegram web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -2015,17 +2015,26 @@
     // SPA навигация с историей браузера
     const pageHistory = [];
     function setActivePage(pageName, push = true){
-      const pages = document.querySelectorAll('.page');
-      pages.forEach(p => p.classList.remove('active'));
-      const target = document.getElementById(pageName + '-page');
-      if (target){
-        target.classList.add('active');
-        if (push){
-          pageHistory.push(pageName);
-          history.pushState({pageName}, '', '#' + pageName);
-        }
-      } else {
-        console.error('Page not found:', pageName);
+      // Sanitize and provide robust fallback for Telegram hashes
+      let targetPage = (pageName || '').toString().trim().replace(/^#/, '').replace(/\/$/, '');
+      if (!targetPage || targetPage === '/' || targetPage === 'index') targetPage = 'main';
+
+      let target = document.getElementById(targetPage + '-page');
+      if (!target){
+        console.warn('Unknown page, falling back to main:', pageName);
+        targetPage = 'main';
+        target = document.getElementById('main-page');
+      }
+      if (!target){
+        console.error('Main page element not found — aborting page switch');
+        return;
+      }
+
+      document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+      target.classList.add('active');
+      if (push){
+        pageHistory.push(targetPage);
+        history.pushState({pageName: targetPage}, '', '#' + targetPage);
       }
     }
     function showPage(pageName) {
@@ -2049,9 +2058,16 @@
     };
     // Инициализация стартовой страницы из hash/по умолчанию
     (function initRouting(){
-      const initial = (location.hash || '#main').replace('#','');
-      pageHistory.length = 0;
-      setActivePage(initial, true);
+      let initial = (location.hash || '#main').toString();
+      try {
+        // Telegram sometimes provides empty or malformed hash
+        initial = initial.replace(/^#?/, '#');
+        const clean = initial.replace('#','').trim();
+        setActivePage(clean || 'main', true);
+      } catch (e) {
+        console.warn('Init routing failed, fallback to main:', e);
+        setActivePage('main', true);
+      }
     })();
 
     function testNavigation() {


### PR DESCRIPTION
Improve SPA navigation robustness to prevent blank screens.

The previous SPA routing logic did not gracefully handle empty or malformed `location.hash` values, which can occur when opening the Telegram Web App. This resulted in no page being activated, leading to a blank screen. The changes ensure that `setActivePage` always falls back to the 'main' page if the target is invalid or not found, and `initRouting` is hardened to sanitize the initial hash.

---
<a href="https://cursor.com/background-agent?bcId=bc-300744d1-b470-4320-ade1-6d933b17a18f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-300744d1-b470-4320-ade1-6d933b17a18f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

