### PR TITLE
Fix back button in grammar section

### DIFF
--- a/grammar-ui.css
+++ b/grammar-ui.css
@@ -13,6 +13,14 @@
 #grammar-page { background: var(--tg-bg); }
 #grammar-page .header { background: transparent; color: var(--tg-text); }
 
+/* Ensure Back button is visible on light backgrounds inside Grammar */
+#grammar-page .back-btn {
+  background: rgba(17, 24, 39, 0.06);
+  color: var(--tg-text);
+  border: 1px solid var(--tg-card-border);
+}
+#grammar-page .back-btn:hover { background: rgba(17, 24, 39, 0.1); }
+
 .tg-card {
   background: var(--tg-card);
   border: 1px solid var(--tg-card-border);

--- a/grammar.js
+++ b/grammar.js
@@ -262,6 +262,14 @@
       oldShow(id);
       if (id === 'grammar'){ path.length = 0; render(); }
     };
+
+    // Expose Grammar back handler for global Back button
+    window.grammarBack = function(){
+      const page = pageEl();
+      if (!page || !page.classList.contains('active')) return false;
+      if (path.length > 0){ path.pop(); render(); return true; }
+      return false;
+    };
   }
 
   document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -2043,6 +2043,10 @@
       setActivePage(pageName, true);
     }
     function goBack(){
+      // First, if Grammar page can handle internal back, do it
+      if (typeof window.grammarBack === 'function' && window.grammarBack()){
+        return;
+      }
       if (pageHistory.length > 1){
         history.back();
         return;


### PR DESCRIPTION
Ensures the Back button navigates correctly within the Grammar section and is visible on light backgrounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-082bf94f-9c92-42e4-9873-fc577f0ea6e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-082bf94f-9c92-42e4-9873-fc577f0ea6e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

