### PR TITLE
Fix vocabulary section navigation and word of the day

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,32 +409,9 @@
       </div>
 
       <div class="content">
-        <h2>Слова дня - 2 августа 2025</h2>
+        <h2 id="daily-words-date">Слова дня - </h2>
         
-        <div class="grammar-content">
-          <h3>🎯 Сегодняшние слова</h3>
-          
-          <div class="word-card">
-            <h4>🌟 Accomplish</h4>
-            <p><strong>Перевод:</strong> достигать, выполнять</p>
-            <p><strong>Пример:</strong> She accomplished her goal of learning English.</p>
-            <p><em>Она достигла своей цели изучения английского.</em></p>
-          </div>
-          
-          <div class="word-card">
-            <h4>💡 Perseverance</h4>
-            <p><strong>Перевод:</strong> настойчивость, упорство</p>
-            <p><strong>Пример:</strong> His perseverance helped him succeed.</p>
-            <p><em>Его настойчивость помогла ему добиться успеха.</em></p>
-          </div>
-          
-          <div class="word-card">
-            <h4>🚀 Endeavor</h4>
-            <p><strong>Перевод:</strong> стремление, попытка</p>
-            <p><strong>Пример:</strong> Learning a new language is a worthwhile endeavor.</p>
-            <p><em>Изучение нового языка - стоящее стремление.</em></p>
-          </div>
-        </div>
+        <div id="daily-word-container" class="grammar-content"></div>
       </div>
     </div>
 
@@ -2032,6 +2009,1738 @@
         </div>
       </div>
     </div>
+
+    <!-- Страница Vocabulary -->
+    <div id="vocabulary-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>🧠 Vocabulary</h1>
+      </div>
+
+      <div class="content">
+        <h2>Словарные разделы</h2>
+        
+        <div class="section-grid">
+          <div class="section-card" onclick="showPage('daily-words')">
+            <h3>📅 Слова дня</h3>
+            <p>Новые слова каждый день</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('topics')">
+            <h3>📚 Тематические слова</h3>
+            <p>Слова по темам</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('idioms')">
+            <h3>💬 Идиомы</h3>
+            <p>Популярные выражения</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('phrasal-verbs')">
+            <h3>🔗 Фразовые глаголы</h3>
+            <p>Важные фразовые глаголы</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Daily Words -->
+    <div id="daily-words-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>📅 Слова дня</h1>
+      </div>
+
+      <div class="content">
+        <h2 id="daily-words-date">Слова дня - </h2>
+        
+        <div id="daily-word-container" class="grammar-content"></div>
+      </div>
+    </div>
+
+    <!-- Страница Topics -->
+    <div id="topics-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>📚 Тематические слова</h1>
+      </div>
+
+      <div class="content">
+        <h2>Слова по темам</h2>
+        
+        <div class="section-grid">
+          <div class="section-card" onclick="showPage('family-words')">
+            <h3>👨‍👩‍👧‍👦 Семья</h3>
+            <p>Слова о семье и родственниках</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('work-words')">
+            <h3>💼 Работа</h3>
+            <p>Профессии и рабочая лексика</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('food-words')">
+            <h3>🍕 Еда</h3>
+            <p>Продукты и блюда</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('travel-words')">
+            <h3>✈️ Путешествия</h3>
+            <p>Туризм и транспорт</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Practice -->
+    <div id="practice-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>✍️ Practice</h1>
+      </div>
+
+      <div class="content">
+        <h2>Практические упражнения</h2>
+        
+        <div class="section-grid">
+          <div class="section-card" onclick="openSection('listening')">
+            <h3>🎧 Аудирование</h3>
+            <p>Упражнения на понимание речи</p>
+          </div>
+          
+          <div class="section-card" onclick="openSection('reading')">
+            <h3>📖 Чтение</h3>
+            <p>Тексты и понимание</p>
+          </div>
+          
+          <div class="section-card" onclick="openSection('writing')">
+            <h3>✏️ Письмо</h3>
+            <p>Написание текстов</p>
+          </div>
+          
+          <div class="section-card" onclick="openSection('speaking')">
+            <h3>🗣️ Говорение</h3>
+            <p>Разговорная практика</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Games -->
+    <div id="games-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>🎮 Игры</h1>
+      </div>
+
+      <div class="content">
+        <h2>Обучающие игры</h2>
+        
+        <div class="section-grid">
+          <div class="section-card" onclick="openSection('word_guess')">
+            <h3>🎯 Угадай слово</h3>
+            <p>Угадайте слово по описанию</p>
+          </div>
+          
+          <div class="section-card" onclick="openSection('memory')">
+            <h3>🧠 Память</h3>
+            <p>Найдите пары слов</p>
+          </div>
+          
+          <div class="section-card" onclick="openSection('quiz')">
+            <h3>❓ Викторина</h3>
+            <p>Ответьте на вопросы</p>
+          </div>
+          
+          <div class="section-card" onclick="openSection('puzzle')">
+            <h3>🧩 Головоломка</h3>
+            <p>Соберите предложение</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Full Version -->
+    <div id="full-version-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>🔐 Полная версия</h1>
+      </div>
+
+      <div class="content">
+        <h2>Что включено в полную версию?</h2>
+        
+        <div class="premium-features">
+          <div class="feature-card">
+            <h3>🎯 IELTS Practice Tests</h3>
+            <p>Полные тесты для подготовки к IELTS</p>
+          </div>
+          
+          <div class="feature-card">
+            <h3>📊 Подробная статистика</h3>
+            <p>Отслеживание прогресса и достижений</p>
+          </div>
+          
+          <div class="feature-card">
+            <h3>🎧 Аудио материалы</h3>
+            <p>Озвученные тексты и диалоги</p>
+          </div>
+          
+          <div class="feature-card">
+            <h3>📱 Персональный план</h3>
+            <p>Индивидуальная программа обучения</p>
+          </div>
+          
+          <div class="feature-card">
+            <h3>💬 Чат с преподавателем</h3>
+            <p>Поддержка от опытных учителей</p>
+          </div>
+          
+          <div class="feature-card">
+            <h3>🏆 Сертификаты</h3>
+            <p>Получение сертификатов по уровням</p>
+          </div>
+        </div>
+        
+        <button class="btn primary" onclick="contactSupport()">
+          📞 Связаться с поддержкой
+        </button>
+      </div>
+    </div>
+
+    <!-- Страница Test -->
+    <div id="test-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>🧪 Тест</h1>
+      </div>
+
+      <div class="content">
+        <h2>Тестовая страница</h2>
+        
+        <p>Если вы видите эту страницу, значит навигация работает правильно!</p>
+        
+        <button class="btn" onclick="testAlert()">Тест уведомления</button>
+        <button class="btn secondary" onclick="showPage('main')">Вернуться в главное меню</button>
+      </div>
+    </div>
+
+    <!-- Страница Present Perfect -->
+    <div id="present-perfect-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>✅ Present Perfect</h1>
+      </div>
+
+      <div class="content">
+        <h2>Настоящее совершенное время</h2>
+        
+        <div class="grammar-content">
+          <div class="word-card">
+            <h4>📖 Формула</h4>
+            <p><strong>Утверждение:</strong> Subject + have/has + V3 (past participle)</p>
+            <p><strong>Отрицание:</strong> Subject + have/has + not + V3</p>
+            <p><strong>Вопрос:</strong> Have/Has + Subject + V3?</p>
+          </div>
+          
+          <div class="word-card">
+            <h4>🎯 Примеры</h4>
+            <ul>
+              <li>I <strong>have finished</strong> my homework. (Я закончил домашнюю работу)</li>
+              <li>She <strong>has visited</strong> Paris three times. (Она была в Париже три раза)</li>
+              <li>We <strong>have never been</strong> to Italy. (Мы никогда не были в Италии)</li>
+              <li><strong>Have</strong> you <strong>eaten</strong> yet? (Ты уже поел?)</li>
+              <li>He <strong>hasn't called</strong> me today. (Он не звонил мне сегодня)</li>
+              <li>They <strong>have just arrived</strong>. (Они только что приехали)</li>
+            </ul>
+          </div>
+          
+          <div class="word-card">
+            <h4>⏰ Когда используется</h4>
+            <ul>
+              <li><strong>Действие произошло в прошлом, но важно сейчас:</strong> I have lost my keys. (не могу открыть дверь)</li>
+              <li><strong>Жизненный опыт:</strong> She has been to Japan. (Она была в Японии)</li>
+              <li><strong>Действие, завершившееся недавно:</strong> We've just arrived. (Мы только что приехали)</li>
+              <li><strong>Действие началось в прошлом и длится до сих пор:</strong> I have lived here for 5 years. (Я живу здесь 5 лет)</li>
+              <li><strong>Результат действия важен в настоящем:</strong> She has finished her work. (Теперь она свободна)</li>
+              <li><strong>Опыт с ever/never:</strong> Have you ever tried sushi? (Ты когда-нибудь пробовал суши?)</li>
+            </ul>
+          </div>
+          
+          <div class="word-card">
+            <h4>🔍 Особенности</h4>
+            <ul>
+              <li><strong>3-е лицо единственного числа:</strong> использует has вместо have</li>
+              <li><strong>Неправильные глаголы:</strong> нужно знать V3 форму (go → gone, see → seen)</li>
+              <li><strong>Регулярные глаголы:</strong> добавляется -ed (work → worked, play → played)</li>
+              <li><strong>Отрицания:</strong> haven't/hasn't + V3</li>
+              <li><strong>Вопросы:</strong> Have/Has + Subject + V3?</li>
+            </ul>
+          </div>
+          
+          <div class="word-card">
+            <h4>📝 Частые наречия</h4>
+            <ul>
+              <li>ever (когда-либо), never (никогда), already (уже)</li>
+              <li>yet (еще не/уже), just (только что), recently (недавно)</li>
+              <li>so far (пока что), lately (в последнее время)</li>
+              <li>since (с какого-то момента), for (в течение)</li>
+              <li>this week/month/year (на этой неделе/месяце/году)</li>
+            </ul>
+          </div>
+          
+          <div class="word-card">
+            <h4>🔄 Сравнение с Past Simple</h4>
+            <ul>
+              <li><strong>Present Perfect:</strong> I have seen that movie. (когда именно — неважно)</li>
+              <li><strong>Past Simple:</strong> I saw that movie yesterday. (вчера — указано время)</li>
+              <li><strong>Present Perfect:</strong> She has lived here for 10 years. (живет до сих пор)</li>
+              <li><strong>Past Simple:</strong> She lived here for 10 years. (жила, но больше не живет)</li>
+            </ul>
+          </div>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Present Perfect</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Выберите правильную форму:</p>
+            <p>I _____ (finish) my work.</p>
+            <button class="test-btn" onclick="checkAnswer('finish', 'finished', 'have finished', 'have finished')">A) finish</button>
+            <button class="test-btn" onclick="checkAnswer('finish', 'finished', 'have finished', 'have finished')">B) finished</button>
+            <button class="test-btn" onclick="checkAnswer('finish', 'finished', 'have finished', 'have finished')">C) have finished</button>
+            <button class="test-btn" onclick="checkAnswer('finish', 'finished', 'have finished', 'have finished')">D) have finished</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Выберите правильное предложение:</p>
+            <button class="test-btn" onclick="checkAnswer('She has went', 'She has gone', 'She went', 'She has gone')">A) She has went</button>
+            <button class="test-btn" onclick="checkAnswer('She has went', 'She has gone', 'She went', 'She has gone')">B) She has gone</button>
+            <button class="test-btn" onclick="checkAnswer('She has went', 'She has gone', 'She went', 'She has gone')">C) She went</button>
+            <button class="test-btn" onclick="checkAnswer('She has went', 'She has gone', 'She went', 'She has gone')">D) She has gone</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Выберите правильную отрицательную форму:</p>
+            <p>He _____ (call) me today.</p>
+            <button class="test-btn" onclick="checkAnswer('hasn\'t called', 'hasn\'t call', 'didn\'t called', 'hasn\'t called')">A) hasn't called</button>
+            <button class="test-btn" onclick="checkAnswer('hasn\'t called', 'hasn\'t call', 'didn\'t called', 'hasn\'t called')">B) hasn't call</button>
+            <button class="test-btn" onclick="checkAnswer('hasn\'t called', 'hasn\'t call', 'didn\'t called', 'hasn\'t called')">C) didn't called</button>
+            <button class="test-btn" onclick="checkAnswer('hasn\'t called', 'hasn\'t call', 'didn\'t called', 'hasn\'t called')">D) hasn't called</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Past Simple -->
+    <div id="past-simple-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>📚 Past Simple</h1>
+      </div>
+
+      <div class="content">
+        <h2>Прошедшее простое время</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Формула</h3>
+          <p><strong>Утверждение:</strong> Subject + V2 (вторая форма глагола)</p>
+          <p><strong>Отрицание:</strong> Subject + didn't + V1</p>
+          <p><strong>Вопрос:</strong> Did + Subject + V1?</p>
+          
+          <h3>🎯 Примеры</h3>
+          <ul>
+            <li>I <strong>watched</strong> a movie yesterday. (Я смотрел фильм вчера)</li>
+            <li>They <strong>went</strong> to Paris in 2020. (Они ездили в Париж в 2020 году)</li>
+            <li>He <strong>finished</strong> his homework an hour ago. (Он закончил домашнюю работу час назад)</li>
+            <li>She <strong>didn't like</strong> the movie. (Ей не понравился фильм)</li>
+            <li><strong>Did</strong> you <strong>see</strong> that film? (Ты видел тот фильм?)</li>
+            <li>We <strong>visited</strong> our grandparents last week. (Мы навещали бабушку и дедушку на прошлой неделе)</li>
+          </ul>
+          
+          <h3>⏰ Когда используется</h3>
+          <ul>
+            <li><strong>Завершённые действия в прошлом:</strong> I visited London last year.</li>
+            <li><strong>Последовательные действия в прошлом:</strong> She entered the room, turned on the light, and sat down.</li>
+            <li><strong>Регулярные действия в прошлом:</strong> We always played outside after school.</li>
+            <li><strong>Конкретные моменты в прошлом:</strong> The train arrived at 8 PM.</li>
+            <li><strong>Исторические события:</strong> World War II ended in 1945.</li>
+            <li><strong>Действия, которые больше не происходят:</strong> I lived in Moscow for 5 years. (теперь живу в другом месте)</li>
+          </ul>
+          
+          <h3>🔍 Особенности</h3>
+          <ul>
+            <li><strong>Правильные глаголы:</strong> добавляется -ed (watched, played, worked)</li>
+            <li><strong>Неправильные глаголы:</strong> уникальная форма (went, saw, ate, came)</li>
+            <li><strong>Отрицания:</strong> didn't + V1 (глагол в базовой форме)</li>
+            <li><strong>Вопросы:</strong> Did + Subject + V1?</li>
+            <li><strong>После did глагол всегда в базовой форме:</strong> Did you go? (не Did you went?)</li>
+          </ul>
+          
+          <h3>📝 Частые наречия</h3>
+          <ul>
+            <li>yesterday (вчера), last week/month/year (на прошлой неделе/в прошлом месяце/году)</li>
+            <li>in 2010 (в 2010 году), two days ago (два дня назад)</li>
+            <li>then (тогда), when I was a child (когда я был ребенком)</li>
+            <li>once (однажды), in the past (в прошлом)</li>
+            <li>ago (назад), earlier (раньше)</li>
+          </ul>
+          
+          <h3>🔄 Сравнение с Present Perfect</h3>
+          <ul>
+            <li><strong>Past Simple:</strong> I saw that movie yesterday. (вчера — указано время)</li>
+            <li><strong>Present Perfect:</strong> I have seen that movie. (когда именно — неважно)</li>
+            <li><strong>Past Simple:</strong> She lived here for 10 years. (жила, но больше не живет)</li>
+            <li><strong>Present Perfect:</strong> She has lived here for 10 years. (живет до сих пор)</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Past Simple</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Выберите правильную форму:</p>
+            <p>I _____ (go) to the cinema yesterday.</p>
+            <button class="test-btn" onclick="checkAnswer('go', 'went', 'gone', 'went')">A) go</button>
+            <button class="test-btn" onclick="checkAnswer('go', 'went', 'gone', 'went')">B) went</button>
+            <button class="test-btn" onclick="checkAnswer('go', 'went', 'gone', 'went')">C) gone</button>
+            <button class="test-btn" onclick="checkAnswer('go', 'went', 'gone', 'went')">D) went</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Выберите правильное предложение:</p>
+            <button class="test-btn" onclick="checkAnswer('Did you went', 'Did you go', 'Do you went', 'Did you go')">A) Did you went</button>
+            <button class="test-btn" onclick="checkAnswer('Did you went', 'Did you go', 'Do you went', 'Did you go')">B) Did you go</button>
+            <button class="test-btn" onclick="checkAnswer('Did you went', 'Did you go', 'Do you went', 'Did you go')">C) Do you went</button>
+            <button class="test-btn" onclick="checkAnswer('Did you went', 'Did you go', 'Do you went', 'Did you go')">D) Did you go</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Выберите правильную отрицательную форму:</p>
+            <p>She _____ (like) the movie.</p>
+            <button class="test-btn" onclick="checkAnswer('didn\'t like', 'didn\'t liked', 'not like', 'didn\'t like')">A) didn't like</button>
+            <button class="test-btn" onclick="checkAnswer('didn\'t like', 'didn\'t liked', 'not like', 'didn\'t like')">B) didn't liked</button>
+            <button class="test-btn" onclick="checkAnswer('didn\'t like', 'didn\'t liked', 'not like', 'didn\'t like')">C) not like</button>
+            <button class="test-btn" onclick="checkAnswer('didn\'t like', 'didn\'t liked', 'not like', 'didn\'t like')">D) didn't like</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Future Simple -->
+    <div id="future-simple-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>🔮 Future Simple</h1>
+      </div>
+
+      <div class="content">
+        <h2>Будущее простое время</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Формула</h3>
+          <p><strong>Утверждение:</strong> Subject + will + V1 (инфинитив без to)</p>
+          <p><strong>Отрицание:</strong> Subject + will not (won't) + V1</p>
+          <p><strong>Вопрос:</strong> Will + Subject + V1?</p>
+          
+          <h3>🎯 Примеры</h3>
+          <ul>
+            <li>I <strong>will call</strong> you later. (Я позвоню тебе позже)</li>
+            <li>We <strong>will go</strong> to the beach tomorrow. (Мы поедем на пляж завтра)</li>
+            <li>I think it <strong>will rain</strong> soon. (Думаю, скоро пойдет дождь)</li>
+            <li>She <strong>won't come</strong> to the party. (Она не придет на вечеринку)</li>
+            <li><strong>Will</strong> you <strong>help</strong> me? (Ты поможешь мне?)</li>
+            <li>They <strong>will visit</strong> us next week. (Они посетят нас на следующей неделе)</li>
+          </ul>
+          
+          <h3>⏰ Когда используется</h3>
+          <ul>
+            <li><strong>Спонтанные решения:</strong> Oh, I forgot my wallet! I will go back and get it.</li>
+            <li><strong>Обещания, угрозы, прогнозы:</strong> She will be a great doctor.</li>
+            <li><strong>Действия в будущем без точного плана:</strong> They will visit us next week.</li>
+            <li><strong>Факты о будущем:</strong> The sun will rise tomorrow.</li>
+            <li><strong>Предсказания с I think, I hope, I believe:</strong> I think it will rain.</li>
+            <li><strong>Предложения и просьбы:</strong> I will help you with that.</li>
+          </ul>
+          
+          <h3>🔍 Особенности</h3>
+          <ul>
+            <li><strong>После will глагол всегда в базовой форме:</strong> He will go (не will goes)</li>
+            <li><strong>Сокращения:</strong> will not = won't</li>
+            <li><strong>В вопросах:</strong> Will + Subject + V1?</li>
+            <li><strong>В отрицаниях:</strong> Subject + won't + V1</li>
+            <li><strong>Не добавляется to после will:</strong> They will come (не will to come)</li>
+          </ul>
+          
+          <h3>📝 Частые наречия</h3>
+          <ul>
+            <li>tomorrow (завтра), next week/month/year (на следующей неделе/в следующем месяце/году)</li>
+            <li>soon (скоро), in 2025 (в 2025 году), in the future (в будущем)</li>
+            <li>I think, I hope, I believe, probably, perhaps</li>
+            <li>later (позже), in a few minutes (через несколько минут)</li>
+          </ul>
+          
+          <h3>🔄 Сравнение с другими способами выражения будущего</h3>
+          <ul>
+            <li><strong>Will:</strong> спонтанные решения, прогнозы</li>
+            <li><strong>Be going to:</strong> планы и намерения</li>
+            <li><strong>Present Continuous:</strong> запланированные действия</li>
+            <li><strong>Present Simple:</strong> расписания и графики</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Future Simple</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Выберите правильную форму:</p>
+            <p>I _____ (call) you tomorrow.</p>
+            <button class="test-btn" onclick="checkAnswer('call', 'will call', 'calls', 'will call')">A) call</button>
+            <button class="test-btn" onclick="checkAnswer('call', 'will call', 'calls', 'will call')">B) will call</button>
+            <button class="test-btn" onclick="checkAnswer('call', 'will call', 'calls', 'will call')">C) calls</button>
+            <button class="test-btn" onclick="checkAnswer('call', 'will call', 'calls', 'will call')">D) will call</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Выберите правильное предложение:</p>
+            <button class="test-btn" onclick="checkAnswer('He will goes', 'He will go', 'He goes', 'He will go')">A) He will goes</button>
+            <button class="test-btn" onclick="checkAnswer('He will goes', 'He will go', 'He goes', 'He will go')">B) He will go</button>
+            <button class="test-btn" onclick="checkAnswer('He will goes', 'He will go', 'He goes', 'He will go')">C) He goes</button>
+            <button class="test-btn" onclick="checkAnswer('He will goes', 'He will go', 'He goes', 'He will go')">D) He will go</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Выберите правильную отрицательную форму:</p>
+            <p>She _____ (come) to the party.</p>
+            <button class="test-btn" onclick="checkAnswer('won\'t come', 'will not comes', 'not come', 'won\'t come')">A) won't come</button>
+            <button class="test-btn" onclick="checkAnswer('won\'t come', 'will not comes', 'not come', 'won\'t come')">B) will not comes</button>
+            <button class="test-btn" onclick="checkAnswer('won\'t come', 'will not comes', 'not come', 'won\'t come')">C) not come</button>
+            <button class="test-btn" onclick="checkAnswer('won\'t come', 'will not comes', 'not come', 'won\'t come')">D) won't come</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Parts of Speech -->
+    <div id="parts-of-speech-page" class="page">
+      <div class="header">
+        <button onclick="goBack()" class="back-btn">← Назад</button>
+        <h1>📌 Части речи</h1>
+      </div>
+
+      <div class="content">
+        <h2>Части речи в английском языке</h2>
+        
+        <div class="section-grid">
+          <div class="section-card" onclick="showPage('nouns')">
+            <h3>📝 Nouns (Существительные)</h3>
+            <p>Обозначают людей, животных, предметы, места, идеи</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('pronouns')">
+            <h3>👤 Pronouns (Местоимения)</h3>
+            <p>Заменяют существительные: he, she, it, they, this, which</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('verbs')">
+            <h3>🏃 Verbs (Глаголы)</h3>
+            <p>Обозначают действия или состояния: run, eat, write, be</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('adjectives')">
+            <h3>🎨 Adjectives (Прилагательные)</h3>
+            <p>Описывают существительные: big, interesting, red, beautiful</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('adverbs')">
+            <h3>⚡ Adverbs (Наречия)</h3>
+            <p>Описывают глаголы, прилагательные, другие наречия</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('prepositions')">
+            <h3>🔗 Prepositions (Предлоги)</h3>
+            <p>Показывают отношения: in, on, at, under, for, with</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('conjunctions')">
+            <h3>🔗 Conjunctions (Союзы)</h3>
+            <p>Соединяют слова и предложения: and, but, or, because</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('interjections')">
+            <h3>💬 Interjections (Междометия)</h3>
+            <p>Выражают эмоции: oh, wow, ouch, hey, hmm</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Nouns -->
+    <div id="nouns-page" class="page">
+      <div class="header">
+        <button onclick="showPage('parts-of-speech')" class="back-btn">← Назад</button>
+        <h1>📝 Nouns (Существительные)</h1>
+      </div>
+
+      <div class="content">
+        <h2>Существительные в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Определение и функция</h3>
+          <p>Обозначают людей, животных, предметы, места, идеи, качества, события или абстрактные понятия. Существительные являются основой большинства предложений, выполняя роль подлежащего или дополнения.</p>
+          <p><strong>Примеры:</strong> teacher, car, happiness, London, cat, beauty, meeting</p>
+          
+          <h3>🔹 Виды существительных</h3>
+          
+          <h4>📊 Countable (исчисляемые) / Uncountable (неисчисляемые)</h4>
+          <ul>
+            <li><strong>Countable:</strong> могут быть посчитаны и имеют формы единственного и множественного числа. Например: one car, two cars; a book, many books.</li>
+            <li><strong>Uncountable:</strong> нельзя посчитать (например, water, happiness, information, advice). Они обычно не имеют формы множественного числа и используются без неопределенного артикля a/an.</li>
+          </ul>
+          
+          <h4>🏷️ Common (нарицательные) / Proper (собственные)</h4>
+          <ul>
+            <li><strong>Common:</strong> общие названия для классов людей, мест, вещей. Пишутся с маленькой буквы (если это не начало предложения). Например: city, book, river.</li>
+            <li><strong>Proper:</strong> имена, названия конкретных людей, мест, организаций, дней недели, месяцев. Всегда пишутся с большой буквы. Например: London, Shakespeare, Monday, Amazon.</li>
+          </ul>
+          
+          <h4>🎭 Abstract (абстрактные) / Concrete (конкретные)</h4>
+          <ul>
+            <li><strong>Abstract:</strong> идеи, концепции, чувства, качества, состояния, которые нельзя потрогать или увидеть. Например: love, freedom, knowledge, courage.</li>
+            <li><strong>Concrete:</strong> то, что можно воспринимать с помощью пяти чувств (увидеть, потрогать, услышать, попробовать на вкус, понюхать). Например: table, tree, music, pizza.</li>
+          </ul>
+          
+          <h3>🎯 Примеры использования в предложении</h3>
+          <ul>
+            <li>My <strong>dog</strong> is very friendly. (dog - подлежащее)</li>
+            <li>She studies <strong>history</strong>. (history - дополнение)</li>
+            <li><strong>The book</strong> is on the table. (book - подлежащее)</li>
+            <li><strong>London</strong> is a beautiful <strong>city</strong>. (London - собственное, city - нарицательное)</li>
+          </ul>
+          
+          <h3>❓ Вопросы</h3>
+          <p>Чтобы определить существительное, можно задать вопросы: <strong>Who? What?</strong> (Кто? Что?)</p>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Существительные могут быть в единственном и множественном числе (множественное число часто образуется добавлением -s/-es).</li>
+            <li>Могут выполнять разные роли в предложении: подлежащее, прямое или косвенное дополнение, именная часть сказуемого, обстоятельство.</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Nouns</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какое слово является существительным?</p>
+            <button class="test-btn" onclick="checkAnswer('run', 'quickly', 'teacher', 'teacher')">A) run</button>
+            <button class="test-btn" onclick="checkAnswer('run', 'quickly', 'teacher', 'teacher')">B) quickly</button>
+            <button class="test-btn" onclick="checkAnswer('run', 'quickly', 'teacher', 'teacher')">C) teacher</button>
+            <button class="test-btn" onclick="checkAnswer('run', 'quickly', 'teacher', 'teacher')">D) teacher</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какое существительное является неисчисляемым?</p>
+            <button class="test-btn" onclick="checkAnswer('book', 'water', 'car', 'water')">A) book</button>
+            <button class="test-btn" onclick="checkAnswer('book', 'water', 'car', 'water')">B) water</button>
+            <button class="test-btn" onclick="checkAnswer('book', 'water', 'car', 'water')">C) car</button>
+            <button class="test-btn" onclick="checkAnswer('book', 'water', 'car', 'water')">D) water</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Какое существительное является собственным?</p>
+            <button class="test-btn" onclick="checkAnswer('city', 'London', 'river', 'London')">A) city</button>
+            <button class="test-btn" onclick="checkAnswer('city', 'London', 'river', 'London')">B) London</button>
+            <button class="test-btn" onclick="checkAnswer('city', 'London', 'river', 'London')">C) river</button>
+            <button class="test-btn" onclick="checkAnswer('city', 'London', 'river', 'London')">D) London</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Sentence Structure -->
+    <div id="sentence-structure-page" class="page">
+      <div class="header">
+        <button onclick="showPage('grammar')" class="back-btn">← Назад</button>
+        <h1>🧱 Структура предложений</h1>
+      </div>
+
+      <div class="content">
+        <h2>Структура предложений в английском языке</h2>
+        
+        <div class="section-grid">
+          <div class="section-card" onclick="showPage('sentence-types')">
+            <h3>📝 Типы предложений</h3>
+            <p>Повествовательные, вопросительные, повелительные, восклицательные</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('sentence-elements')">
+            <h3>🔧 Элементы предложения</h3>
+            <p>Подлежащее, сказуемое, дополнение, обстоятельство</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('word-order')">
+            <h3>📐 Порядок слов</h3>
+            <p>Subject + Verb + Object (SVO)</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('questions')">
+            <h3>❓ Вопросы</h3>
+            <p>Yes/No вопросы, Wh-вопросы, альтернативные вопросы</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('negation')">
+            <h3>🚫 Отрицания</h3>
+            <p>Формирование отрицательных предложений</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('complex-sentences')">
+            <h3>🔗 Сложные предложения</h3>
+            <p>Сложноподчиненные предложения</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('passive-voice')">
+            <h3>🔄 Страдательный залог</h3>
+            <p>Active Voice vs Passive Voice</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Sentence Types -->
+    <div id="sentence-types-page" class="page">
+      <div class="header">
+        <button onclick="showPage('sentence-structure')" class="back-btn">← Назад</button>
+        <h1>📝 Типы предложений</h1>
+      </div>
+
+      <div class="content">
+        <h2>Типы предложений в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 По цели высказывания (Function)</h3>
+          
+          <h4>📢 Declarative (повествовательные)</h4>
+          <p>Используются для утверждения факта, мнения или информации. Заканчиваются точкой.</p>
+          <ul>
+            <li>I like tea. (Я люблю чай.)</li>
+            <li>The sun rises in the east. (Солнце встает на востоке.)</li>
+            <li>She is a teacher. (Она учительница.)</li>
+          </ul>
+          
+          <h4>❓ Interrogative (вопросительные)</h4>
+          <p>Используются для того, чтобы задать вопрос. Заканчиваются вопросительным знаком.</p>
+          <ul>
+            <li>Do you like tea? (Ты любишь чай?)</li>
+            <li>Where do you live? (Где ты живешь?)</li>
+            <li>What time is it? (Который час?)</li>
+          </ul>
+          
+          <h4>⚡ Imperative (повелительные)</h4>
+          <p>Используются для отдачи команды, просьбы, инструкции или совета. Обычно начинаются с глагола и могут не иметь явного подлежащего (подразумевается "you"). Заканчиваются точкой или восклицательным знаком.</p>
+          <ul>
+            <li>Close the door. (Закрой дверь.)</li>
+            <li>Please sit down. (Пожалуйста, сядьте.)</li>
+            <li>Don't be late! (Не опаздывай!)</li>
+          </ul>
+          
+          <h4>💥 Exclamatory (восклицательные)</h4>
+          <p>Используются для выражения сильных эмоций, удивления, восхищения. Заканчиваются восклицательным знаком.</p>
+          <ul>
+            <li>What a day! (Какой день!)</li>
+            <li>How wonderful! (Как прекрасно!)</li>
+            <li>That's amazing! (Это потрясающе!)</li>
+          </ul>
+          
+          <h3>📖 По структуре (Structure)</h3>
+          
+          <h4>📝 Simple Sentence (простое предложение)</h4>
+          <p>Содержит одно независимое (главное) предложение.</p>
+          <ul>
+            <li>The cat slept. (Кот спал.)</li>
+            <li>I like coffee. (Я люблю кофе.)</li>
+            <li>She works in a bank. (Она работает в банке.)</li>
+          </ul>
+          
+          <h4>🔗 Compound Sentence (сложносочиненное предложение)</h4>
+          <p>Содержит два или более независимых предложения, соединенных сочинительным союзом (FANBOYS: For, And, Nor, But, Or, Yet, So).</p>
+          <ul>
+            <li>I like coffee, <strong>and</strong> she likes tea. (Я люблю кофе, а она любит чай.)</li>
+            <li>He was tired, <strong>but</strong> he kept working. (Он был уставшим, но продолжал работать.)</li>
+            <li>You can stay here, <strong>or</strong> you can go home. (Ты можешь остаться здесь или пойти домой.)</li>
+          </ul>
+          
+          <h4>🔗 Complex Sentence (сложноподчиненное предложение)</h4>
+          <p>Содержит одно независимое предложение и одно или несколько зависимых (придаточных) предложений, соединенных подчинительным союзом (e.g., because, although, if, when).</p>
+          <ul>
+            <li>I stayed home <strong>because</strong> it was raining. (Я остался дома, потому что шел дождь.)</li>
+            <li><strong>If</strong> you study, you'll pass the exam. (Если ты будешь учиться, ты сдашь экзамен.)</li>
+            <li><strong>Although</strong> it was late, she kept working. (Хотя было поздно, она продолжала работать.)</li>
+          </ul>
+          
+          <h4>🔗 Compound-Complex Sentence (сложносочиненно-подчиненное предложение)</h4>
+          <p>Содержит два или более независимых предложения и одно или несколько зависимых предложений.</p>
+          <ul>
+            <li>Although it was raining, I went for a walk, <strong>and</strong> I enjoyed it. (Хотя шел дождь, я пошел на прогулку, и мне понравилось.)</li>
+            <li>If you study hard, you'll pass the exam, <strong>but</strong> if you don't, you might fail. (Если ты будешь усердно учиться, ты сдашь экзамен, но если не будешь, можешь провалиться.)</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Типы предложений</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какое предложение является повествовательным?</p>
+            <button class="test-btn" onclick="checkAnswer('Do you like coffee?', 'I like coffee.', 'Close the door!', 'I like coffee.')">A) Do you like coffee?</button>
+            <button class="test-btn" onclick="checkAnswer('Do you like coffee?', 'I like coffee.', 'Close the door!', 'I like coffee.')">B) I like coffee.</button>
+            <button class="test-btn" onclick="checkAnswer('Do you like coffee?', 'I like coffee.', 'Close the door!', 'I like coffee.')">C) Close the door!</button>
+            <button class="test-btn" onclick="checkAnswer('Do you like coffee?', 'I like coffee.', 'Close the door!', 'I like coffee.')">D) I like coffee.</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какое предложение является сложносочиненным?</p>
+            <button class="test-btn" onclick="checkAnswer('I like coffee.', 'I like coffee and she likes tea.', 'I stayed home because it was raining.', 'I like coffee and she likes tea.')">A) I like coffee.</button>
+            <button class="test-btn" onclick="checkAnswer('I like coffee.', 'I like coffee and she likes tea.', 'I stayed home because it was raining.', 'I like coffee and she likes tea.')">B) I like coffee and she likes tea.</button>
+            <button class="test-btn" onclick="checkAnswer('I like coffee.', 'I like coffee and she likes tea.', 'I stayed home because it was raining.', 'I like coffee and she likes tea.')">C) I stayed home because it was raining.</button>
+            <button class="test-btn" onclick="checkAnswer('I like coffee.', 'I like coffee and she likes tea.', 'I stayed home because it was raining.', 'I like coffee and she likes tea.')">D) I like coffee and she likes tea.</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Какое предложение является повелительным?</p>
+            <button class="test-btn" onclick="checkAnswer('What time is it?', 'Please sit down.', 'The sun rises in the east.', 'Please sit down.')">A) What time is it?</button>
+            <button class="test-btn" onclick="checkAnswer('What time is it?', 'Please sit down.', 'The sun rises in the east.', 'Please sit down.')">B) Please sit down.</button>
+            <button class="test-btn" onclick="checkAnswer('What time is it?', 'Please sit down.', 'The sun rises in the east.', 'Please sit down.')">C) The sun rises in the east.</button>
+            <button class="test-btn" onclick="checkAnswer('What time is it?', 'Please sit down.', 'The sun rises in the east.', 'Please sit down.')">D) Please sit down.</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Constructions -->
+    <div id="constructions-page" class="page">
+      <div class="header">
+        <button onclick="showPage('grammar')" class="back-btn">← Назад</button>
+        <h1>🛠 Конструкции</h1>
+      </div>
+
+      <div class="content">
+        <h2>Грамматические конструкции в английском языке</h2>
+        
+        <div class="section-grid">
+          <div class="section-card" onclick="showPage('there-is-are')">
+            <h3>📍 There is / There are</h3>
+            <p>Конструкция для указания на существование чего-либо</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('have-got')">
+            <h3>💎 Have got / Has got</h3>
+            <p>Конструкция для выражения обладания</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('used-to')">
+            <h3>⏰ Used to</h3>
+            <p>Привычные действия или состояния в прошлом</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('be-going-to')">
+            <h3>🎯 Be going to</h3>
+            <p>Намерения и предсказания на будущее</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('it-takes')">
+            <h3>⏱️ It takes</h3>
+            <p>Конструкция для выражения времени, необходимого для действия</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница There is / There are -->
+    <div id="there-is-are-page" class="page">
+      <div class="header">
+        <button onclick="showPage('constructions')" class="back-btn">← Назад</button>
+        <h1>📍 There is / There are</h1>
+      </div>
+
+      <div class="content">
+        <h2>Конструкция для указания на существование чего-либо</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Когда используется</h3>
+          <p>Эта конструкция используется для указания на существование или наличие чего-либо (или кого-либо) в определенном месте или в определенный момент времени. Она отвечает на вопрос "Что (кто) где находится?" или "Что (кто) существует?".</p>
+          <p><strong>Примеры:</strong></p>
+          <ul>
+            <li>There is a book on the table. (На столе есть книга.)</li>
+            <li>There are many people here. (Здесь много людей.)</li>
+          </ul>
+          
+          <h3>🧩 Формулы</h3>
+          <ul>
+            <li><strong>There is + существительное в единственном числе</strong> (или неисчисляемое существительное)</li>
+            <li><strong>There are + существительное во множественном числе</strong></li>
+          </ul>
+          
+          <h3>🎯 Примеры</h3>
+          <ul>
+            <li>There is a cat in the garden. (В саду есть кошка.)</li>
+            <li>There is some milk in the fridge. (В холодильнике есть немного молока.)</li>
+            <li>There are some apples on the plate. (На тарелке есть несколько яблок.)</li>
+            <li>There are two cars in the garage. (В гараже две машины.)</li>
+          </ul>
+          
+          <h3>❓ Вопросы и отрицания</h3>
+          
+          <h4>Вопросы</h4>
+          <p>Вспомогательный глагол (is или are) ставится перед there.</p>
+          <ul>
+            <li>Is there a problem? (Есть проблема?)</li>
+            <li>Are there any new students? (Есть ли новые студенты?)</li>
+            <li>Is there any coffee left? (Остался ли кофе?)</li>
+          </ul>
+          
+          <h4>Отрицания</h4>
+          <p>Частица not добавляется после вспомогательного глагола. Сокращенные формы: there isn't, there aren't.</p>
+          <ul>
+            <li>There isn't any milk. (Нет молока.)</li>
+            <li>There aren't many people. (Не очень много людей.)</li>
+            <li>There isn't a car in the garage. (В гараже нет машины.)</li>
+          </ul>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Эта конструкция может использоваться и в других временах (e.g., There was a cat, There will be a party).</li>
+            <li>Часто используется для представления новой информации.</li>
+            <li>В разговорной речи часто используется сокращение: There's вместо There is.</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: There is / There are</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Выберите правильную форму:</p>
+            <p>______ a lot of books in the library.</p>
+            <button class="test-btn" onclick="checkAnswer('There is', 'There are', 'It is', 'There are')">A) There is</button>
+            <button class="test-btn" onclick="checkAnswer('There is', 'There are', 'It is', 'There are')">B) There are</button>
+            <button class="test-btn" onclick="checkAnswer('There is', 'There are', 'It is', 'There are')">C) It is</button>
+            <button class="test-btn" onclick="checkAnswer('There is', 'There are', 'It is', 'There are')">D) There are</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Выберите правильную форму:</p>
+            <p>______ some water in the bottle.</p>
+            <button class="test-btn" onclick="checkAnswer('There is', 'There are', 'It is', 'There is')">A) There is</button>
+            <button class="test-btn" onclick="checkAnswer('There is', 'There are', 'It is', 'There is')">B) There are</button>
+            <button class="test-btn" onclick="checkAnswer('There is', 'There are', 'It is', 'There is')">C) It is</button>
+            <button class="test-btn" onclick="checkAnswer('There is', 'There are', 'It is', 'There is')">D) There is</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Выберите правильный вопрос:</p>
+            <button class="test-btn" onclick="checkAnswer('Is there any coffee?', 'Are there any coffee?', 'There is any coffee?', 'Is there any coffee?')">A) Is there any coffee?</button>
+            <button class="test-btn" onclick="checkAnswer('Is there any coffee?', 'Are there any coffee?', 'There is any coffee?', 'Is there any coffee?')">B) Are there any coffee?</button>
+            <button class="test-btn" onclick="checkAnswer('Is there any coffee?', 'Are there any coffee?', 'There is any coffee?', 'Is there any coffee?')">C) There is any coffee?</button>
+            <button class="test-btn" onclick="checkAnswer('Is there any coffee?', 'Are there any coffee?', 'There is any coffee?', 'Is there any coffee?')">D) Is there any coffee?</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Common Mistakes -->
+    <div id="common-mistakes-page" class="page">
+      <div class="header">
+        <button onclick="showPage('grammar')" class="back-btn">← Назад</button>
+        <h1>🚫 Общие ошибки</h1>
+      </div>
+
+      <div class="content">
+        <h2>Распространенные ошибки в английском языке</h2>
+        
+        <div class="section-grid">
+          <div class="section-card" onclick="showPage('wrong-verb-forms')">
+            <h3>❌ Неправильные формы глаголов</h3>
+            <p>Ошибки в согласовании, времени, форме глаголов</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('do-does-did-errors')">
+            <h3>🔧 Ошибки с do/does/did</h3>
+            <p>Неправильное использование вспомогательных глаголов</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('word-order')">
+            <h3>📐 Нарушение порядка слов</h3>
+            <p>Ошибки в структуре предложения SVO</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('wrong-prepositions')">
+            <h3>🔗 Неверные предлоги</h3>
+            <p>Ошибки в устойчивых сочетаниях</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('articles')">
+            <h3>📝 Ошибки с артиклями</h3>
+            <p>Неправильное использование a/an/the</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('too-enough')">
+            <h3>⚖️ Too / Enough</h3>
+            <p>Ошибки в порядке слов</p>
+          </div>
+          
+          <div class="section-card" onclick="showPage('false-friends')">
+            <h3>🤝 Ложные друзья переводчика</h3>
+            <p>Слова, похожие на русские, но с другим значением</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Wrong Verb Forms -->
+    <div id="wrong-verb-forms-page" class="page">
+      <div class="header">
+        <button onclick="showPage('common-mistakes')" class="back-btn">← Назад</button>
+        <h1>❌ Неправильные формы глаголов</h1>
+      </div>
+
+      <div class="content">
+        <h2>Ошибки в формах глаголов</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Описание ошибки</h3>
+          <p>Одна из самых частых ошибок – использование неверной формы глагола (например, неправильного времени, лица, числа, или неверной формы неправильного глагола).</p>
+          
+          <h3>❌ Примеры ошибок</h3>
+          <ul>
+            <li><strong>Неправильное согласование по лицу/числу:</strong><br>
+              ❌ He go to school every day.<br>
+              ✅ He <strong>goes</strong> to school every day.</li>
+            
+            <li><strong>Неправильное согласование глагола 'to be' по числу:</strong><br>
+              ❌ They was happy.<br>
+              ✅ They <strong>were</strong> happy.</li>
+            
+            <li><strong>Неправильная третья форма глагола:</strong><br>
+              ❌ I have went home.<br>
+              ✅ I <strong>have gone</strong> home.</li>
+            
+            <li><strong>Неправильная базовая форма после 'did':</strong><br>
+              ❌ She did break the window. (если это Past Simple утверждение)<br>
+              ✅ She <strong>broke</strong> the window.</li>
+          </ul>
+          
+          <h3>✅ Как исправить</h3>
+          <p>Всегда проверяй:</p>
+          <ol>
+            <li><strong>Согласование глагола по лицу и числу</strong> с подлежащим (например, he goes, they go).</li>
+            <li><strong>Правильную форму глагола</strong> для выбранного времени (V1, V2, V3 или -ing форма).</li>
+            <li><strong>Особое внимание удели неправильным глаголам</strong> (Irregular Verbs).</li>
+            <li><strong>После вспомогательных глаголов</strong> основной глагол всегда в базовой форме.</li>
+          </ol>
+          
+          <h3>🔍 Частые ошибки</h3>
+          <ul>
+            <li><strong>3-е лицо единственного числа:</strong> забывают добавлять -s</li>
+            <li><strong>Неправильные глаголы:</strong> путают V2 и V3 формы</li>
+            <li><strong>После did:</strong> используют V2 вместо V1</li>
+            <li><strong>После have/has:</strong> используют V2 вместо V3</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Неправильные формы глаголов</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Исправьте ошибку:</p>
+            <p>He _____ to school every day.</p>
+            <button class="test-btn" onclick="checkAnswer('go', 'goes', 'going', 'goes')">A) go</button>
+            <button class="test-btn" onclick="checkAnswer('go', 'goes', 'going', 'goes')">B) goes</button>
+            <button class="test-btn" onclick="checkAnswer('go', 'goes', 'going', 'goes')">C) going</button>
+            <button class="test-btn" onclick="checkAnswer('go', 'goes', 'going', 'goes')">D) goes</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Исправьте ошибку:</p>
+            <p>I have _____ home.</p>
+            <button class="test-btn" onclick="checkAnswer('went', 'gone', 'go', 'gone')">A) went</button>
+            <button class="test-btn" onclick="checkAnswer('went', 'gone', 'go', 'gone')">B) gone</button>
+            <button class="test-btn" onclick="checkAnswer('went', 'gone', 'go', 'gone')">C) go</button>
+            <button class="test-btn" onclick="checkAnswer('went', 'gone', 'go', 'gone')">D) gone</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Исправьте ошибку:</p>
+            <p>Did you _____ to the party?</p>
+            <button class="test-btn" onclick="checkAnswer('went', 'go', 'gone', 'go')">A) went</button>
+            <button class="test-btn" onclick="checkAnswer('went', 'go', 'gone', 'go')">B) go</button>
+            <button class="test-btn" onclick="checkAnswer('went', 'go', 'gone', 'go')">C) gone</button>
+            <button class="test-btn" onclick="checkAnswer('went', 'go', 'gone', 'go')">D) go</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Pronouns -->
+    <div id="pronouns-page" class="page">
+      <div class="header">
+        <button onclick="showPage('parts-of-speech')" class="back-btn">← Назад</button>
+        <h1>👤 Pronouns (Местоимения)</h1>
+      </div>
+
+      <div class="content">
+        <h2>Местоимения в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Определение и функция</h3>
+          <p>Заменяют существительные (или именные группы), чтобы избежать их повторения и сделать речь более плавной и естественной.</p>
+          <p><strong>Примеры:</strong> he, she, it, they, this, which, myself</p>
+          
+          <h3>🔹 Типы местоимений</h3>
+          
+          <h4>👥 Personal (личные)</h4>
+          <p>Обозначают лицо, говорящего, слушающего или того, о ком идет речь. Меняются по падежам (именительный, объектный).</p>
+          <ul>
+            <li><strong>Именительный падеж (Subjective):</strong> I, you, he, she, it, we, they (используются как подлежащее)</li>
+            <li><strong>Объектный падеж (Objective):</strong> me, you, him, her, it, us, them (используются как дополнение)</li>
+          </ul>
+          
+          <h4>💎 Possessive (притяжательные)</h4>
+          <p>Указывают на принадлежность, отвечают на вопрос "чей?".</p>
+          <ul>
+            <li><strong>Притяжательные местоимения:</strong> mine, yours, his, hers, its, ours, theirs</li>
+            <li><strong>Притяжательные прилагательные (стоят перед существительным):</strong> my, your, his, her, its, our, their</li>
+          </ul>
+          
+          <h4>🔄 Reflexive (возвратные)</h4>
+          <p>Отражают действие обратно на подлежащее, используются, когда подлежащее и дополнение — одно и то же лицо/предмет, или для усиления. Заканчиваются на -self (ед.ч.) или -selves (мн.ч.).</p>
+          <p><strong>Примеры:</strong> myself, yourself, himself, herself, itself, ourselves, yourselves, themselves</p>
+          
+          <h4>🔗 Relative (относительные)</h4>
+          <p>Вводят придаточные предложения, связывая их с главным предложением.</p>
+          <ul>
+            <li>who (для людей)</li>
+            <li>whom (объектный падеж для людей, формально)</li>
+            <li>which (для вещей, животных)</li>
+            <li>that (для людей и вещей)</li>
+            <li>whose (чей)</li>
+          </ul>
+          
+          <h4>👆 Demonstrative (указательные)</h4>
+          <p>Указывают на конкретные объекты, находящиеся рядом или на расстоянии.</p>
+          <ul>
+            <li>this (этот, рядом, ед.ч.)</li>
+            <li>that (тот, далеко, ед.ч.)</li>
+            <li>these (эти, рядом, мн.ч.)</li>
+            <li>those (те, далеко, мн.ч.)</li>
+          </ul>
+          
+          <h4>❓ Indefinite (неопределенные)</h4>
+          <p>Указывают на неопределенные лица, предметы, количества.</p>
+          <p><strong>Примеры:</strong> someone, anybody, nothing, everything, many, few, all</p>
+          
+          <h4>❓ Interrogative (вопросительные)</h4>
+          <p>Используются для формирования вопросов.</p>
+          <p><strong>Примеры:</strong> who, whom, whose, which, what</p>
+          
+          <h3>🎯 Примеры использования в предложении</h3>
+          <ul>
+            <li><strong>She</strong> is my friend. (She заменяет имя)</li>
+            <li>This is <strong>mine</strong>. (mine показывает принадлежность)</li>
+            <li>I did it <strong>myself</strong>. (myself усиливает действие)</li>
+            <li><strong>Who</strong> is there? (Who задает вопрос)</li>
+            <li>The car <strong>that</strong> I bought is red. (that вводит придаточное предложение)</li>
+          </ul>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Местоимения согласуются с существительными, которые они заменяют, по числу, роду и лицу.</li>
+            <li>Правильный выбор местоимения критичен для ясности и корректности речи.</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Pronouns</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какое местоимение является личным в объектном падеже?</p>
+            <button class="test-btn" onclick="checkAnswer('I', 'me', 'my', 'me')">A) I</button>
+            <button class="test-btn" onclick="checkAnswer('I', 'me', 'my', 'me')">B) me</button>
+            <button class="test-btn" onclick="checkAnswer('I', 'me', 'my', 'me')">C) my</button>
+            <button class="test-btn" onclick="checkAnswer('I', 'me', 'my', 'me')">D) me</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какое местоимение является притяжательным?</p>
+            <button class="test-btn" onclick="checkAnswer('he', 'his', 'him', 'his')">A) he</button>
+            <button class="test-btn" onclick="checkAnswer('he', 'his', 'him', 'his')">B) his</button>
+            <button class="test-btn" onclick="checkAnswer('he', 'his', 'him', 'his')">C) him</button>
+            <button class="test-btn" onclick="checkAnswer('he', 'his', 'him', 'his')">D) his</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Какое местоимение является возвратным?</p>
+            <button class="test-btn" onclick="checkAnswer('you', 'your', 'yourself', 'yourself')">A) you</button>
+            <button class="test-btn" onclick="checkAnswer('you', 'your', 'yourself', 'yourself')">B) your</button>
+            <button class="test-btn" onclick="checkAnswer('you', 'your', 'yourself', 'yourself')">C) yourself</button>
+            <button class="test-btn" onclick="checkAnswer('you', 'your', 'yourself', 'yourself')">D) yourself</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Verbs -->
+    <div id="verbs-page" class="page">
+      <div class="header">
+        <button onclick="showPage('parts-of-speech')" class="back-btn">← Назад</button>
+        <h1>🏃 Verbs (Глаголы)</h1>
+      </div>
+
+      <div class="content">
+        <h2>Глаголы в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Определение и функция</h3>
+          <p>Обозначают действия (e.g., run, eat, write) или состояния (e.g., be, seem, know). Глагол является центральным элементом сказуемого в предложении и необходим для его существования.</p>
+          
+          <h3>🔹 Основные формы глаголов</h3>
+          
+          <h4>📝 Base Form (инфинитив без to)</h4>
+          <p>Основная, словарная форма глагола. Используется с модальными глаголами, в Present Simple (кроме 3-го л. ед.ч.).</p>
+          <p><strong>Примеры:</strong> run, think, go</p>
+          
+          <h4>📚 Past Simple Form (V2)</h4>
+          <p>Используется для образования Past Simple.</p>
+          <ul>
+            <li><strong>Для правильных глаголов:</strong> добавляется окончание -ed (e.g., play → played, work → worked)</li>
+            <li><strong>Для неправильных глаголов:</strong> имеет уникальную форму, которую нужно запомнить (e.g., go → went, see → saw)</li>
+          </ul>
+          
+          <h4>✅ Past Participle Form (V3)</h4>
+          <p>Третья форма глагола, используется для образования совершенных времен (Perfect Tenses) и пассивного залога.</p>
+          <ul>
+            <li><strong>Для правильных глаголов:</strong> та же, что и V2 (e.g., played, worked)</li>
+            <li><strong>Для неправильных глаголов:</strong> уникальная форма (e.g., gone, seen)</li>
+          </ul>
+          
+          <h4>🔄 Present Participle Form (-ing form)</h4>
+          <p>Образуется добавлением -ing к базовой форме. Используется для образования длительных времен (Continuous Tenses), а также как герундий (существительное) или причастие (прилагательное).</p>
+          <p><strong>Примеры:</strong> running, thinking</p>
+          
+          <h3>🔹 Типы глаголов</h3>
+          
+          <h4>📏 Regular (правильные)</h4>
+          <p>Образуют V2 и V3 путем добавления -ed к базовой форме.</p>
+          <p><strong>Примеры:</strong> walk - walked - walked</p>
+          
+          <h4>❌ Irregular (неправильные)</h4>
+          <p>Имеют нестандартные V2 и V3 формы. Их нужно заучивать.</p>
+          <p><strong>Примеры:</strong> eat - ate - eaten</p>
+          
+          <h4>🔄 Transitive (переходные)</h4>
+          <p>Требуют прямого дополнения, чтобы передать смысл действия.</p>
+          <p><strong>Примеры:</strong> read a book, eat dinner</p>
+          
+          <h4>🔄 Intransitive (непереходные)</h4>
+          <p>Не требуют прямого дополнения, чтобы иметь полный смысл.</p>
+          <p><strong>Примеры:</strong> sleep, arrive</p>
+          
+          <h4>🔧 Auxiliary (вспомогательные)</h4>
+          <p>Используются с основными глаголами для образования времен, залогов, вопросов и отрицаний.</p>
+          <p><strong>Примеры:</strong> do, be, have</p>
+          
+          <h4>🎯 Modal (модальные)</h4>
+          <p>Выражают возможность, необходимость, разрешение, обязанность. После них основной глагол всегда в базовой форме.</p>
+          <p><strong>Примеры:</strong> can, may, must, should</p>
+          
+          <h3>🎯 Примеры использования в предложении</h3>
+          <ul>
+            <li>He <strong>runs</strong> fast. (действие, Present Simple)</li>
+            <li>I <strong>am</strong> happy. (состояние, глагол 'to be')</li>
+            <li>They <strong>have been waiting</strong>. (совершенное длительное время)</li>
+            <li>She <strong>reads</strong> books every day. (правильный глагол)</li>
+            <li>He <strong>went</strong> home. (неправильный глагол)</li>
+          </ul>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Глаголы изменяются по временам, лицам и числам.</li>
+            <li>Могут быть в разных залогах (активный: She cleaned the room.; пассивный: The room was cleaned by her.).</li>
+            <li>Неправильные глаголы нужно заучивать отдельно (см. раздел "Irregular Verbs").</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Verbs</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какая форма глагола используется в Present Simple для 3-го лица единственного числа?</p>
+            <button class="test-btn" onclick="checkAnswer('Base form', 'V2', 'V2 + s', 'Base form + s')">A) Base form</button>
+            <button class="test-btn" onclick="checkAnswer('Base form', 'V2', 'V2 + s', 'Base form + s')">B) V2</button>
+            <button class="test-btn" onclick="checkAnswer('Base form', 'V2', 'V2 + s', 'Base form + s')">C) V2 + s</button>
+            <button class="test-btn" onclick="checkAnswer('Base form', 'V2', 'V2 + s', 'Base form + s')">D) Base form + s</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какая форма глагола используется для образования Perfect Tenses?</p>
+            <button class="test-btn" onclick="checkAnswer('Base form', 'V2', 'V3', 'V3')">A) Base form</button>
+            <button class="test-btn" onclick="checkAnswer('Base form', 'V2', 'V3', 'V3')">B) V2</button>
+            <button class="test-btn" onclick="checkAnswer('Base form', 'V2', 'V3', 'V3')">C) V3</button>
+            <button class="test-btn" onclick="checkAnswer('Base form', 'V2', 'V3', 'V3')">D) V3</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Какой тип глагола требует прямого дополнения?</p>
+            <button class="test-btn" onclick="checkAnswer('Intransitive', 'Transitive', 'Auxiliary', 'Transitive')">A) Intransitive</button>
+            <button class="test-btn" onclick="checkAnswer('Intransitive', 'Transitive', 'Auxiliary', 'Transitive')">B) Transitive</button>
+            <button class="test-btn" onclick="checkAnswer('Intransitive', 'Transitive', 'Auxiliary', 'Transitive')">C) Auxiliary</button>
+            <button class="test-btn" onclick="checkAnswer('Intransitive', 'Transitive', 'Auxiliary', 'Transitive')">D) Transitive</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Adjectives -->
+    <div id="adjectives-page" class="page">
+      <div class="header">
+        <button onclick="showPage('parts-of-speech')" class="back-btn">← Назад</button>
+        <h1>🎨 Adjectives (Прилагательные)</h1>
+      </div>
+
+      <div class="content">
+        <h2>Прилагательные в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Определение и функция</h3>
+          <p>Описывают или характеризуют существительные и местоимения, добавляя к ним информацию о качестве, количестве, размере, цвете и т.д. Отвечают на вопросы "Какой?" "Какая?" "Какое?" "Какие?".</p>
+          <p><strong>Примеры:</strong> big, interesting, red, tired, tall, beautiful</p>
+          
+          <h3>🔹 Степени сравнения</h3>
+          <p>Прилагательные изменяются по степеням сравнения, чтобы показать разную степень качества:</p>
+          
+          <h4>📊 Positive Degree (положительная степень)</h4>
+          <p>Базовая форма прилагательного, без сравнения.</p>
+          <p><strong>Примеры:</strong> big, beautiful</p>
+          
+          <h4>📈 Comparative Degree (сравнительная степень)</h4>
+          <p>Используется для сравнения двух предметов или групп. Образуется добавлением -er (для коротких прилагательных) или слова more (для длинных).</p>
+          <p><strong>Примеры:</strong> bigger, more beautiful</p>
+          
+          <h4>🏆 Superlative Degree (превосходная степень)</h4>
+          <p>Используется для сравнения трех и более предметов или групп, указывая на высшую степень качества. Образуется добавлением -est (для коротких прилагательных) или слова most (для длинных). Всегда используется с определенным артиклем the.</p>
+          <p><strong>Примеры:</strong> the biggest, the most beautiful</p>
+          
+          <h3>🎯 Примеры использования в предложении</h3>
+          <ul>
+            <li>A <strong>beautiful</strong> day. (описывает day)</li>
+            <li>The <strong>tallest</strong> building in the city. (сравнивает с другими зданиями)</li>
+            <li>This is a <strong>red</strong> car. (описывает car)</li>
+            <li>He is <strong>smarter</strong> than his brother. (сравнительная степень)</li>
+          </ul>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Прилагательные обычно ставятся перед существительными, которые они описывают (e.g., a blue sky).</li>
+            <li>Могут стоять после глаголов состояния (e.g., He is happy).</li>
+            <li>Некоторые прилагательные не имеют степеней сравнения (e.g., dead, perfect).</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Adjectives</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какая степень сравнения используется для сравнения двух предметов?</p>
+            <button class="test-btn" onclick="checkAnswer('Positive', 'Comparative', 'Superlative', 'Comparative')">A) Positive</button>
+            <button class="test-btn" onclick="checkAnswer('Positive', 'Comparative', 'Superlative', 'Comparative')">B) Comparative</button>
+            <button class="test-btn" onclick="checkAnswer('Positive', 'Comparative', 'Superlative', 'Comparative')">C) Superlative</button>
+            <button class="test-btn" onclick="checkAnswer('Positive', 'Comparative', 'Superlative', 'Comparative')">D) Comparative</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какая форма прилагательного используется в превосходной степени?</p>
+            <button class="test-btn" onclick="checkAnswer('big', 'bigger', 'the biggest', 'the biggest')">A) big</button>
+            <button class="test-btn" onclick="checkAnswer('big', 'bigger', 'the biggest', 'the biggest')">B) bigger</button>
+            <button class="test-btn" onclick="checkAnswer('big', 'bigger', 'the biggest', 'the biggest')">C) the biggest</button>
+            <button class="test-btn" onclick="checkAnswer('big', 'bigger', 'the biggest', 'the biggest')">D) the biggest</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Где обычно стоят прилагательные в английском предложении?</p>
+            <button class="test-btn" onclick="checkAnswer('После существительного', 'Перед существительным', 'В конце предложения', 'Перед существительным')">A) После существительного</button>
+            <button class="test-btn" onclick="checkAnswer('После существительного', 'Перед существительным', 'В конце предложения', 'Перед существительным')">B) Перед существительным</button>
+            <button class="test-btn" onclick="checkAnswer('После существительного', 'Перед существительным', 'В конце предложения', 'Перед существительным')">C) В конце предложения</button>
+            <button class="test-btn" onclick="checkAnswer('После существительного', 'Перед существительным', 'В конце предложения', 'Перед существительным')">D) Перед существительным</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Adverbs -->
+    <div id="adverbs-page" class="page">
+      <div class="header">
+        <button onclick="showPage('parts-of-speech')" class="back-btn">← Назад</button>
+        <h1>⚡ Adverbs (Наречия)</h1>
+      </div>
+
+      <div class="content">
+        <h2>Наречия в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Определение и функция</h3>
+          <p>Описывают глаголы, прилагательные, другие наречия или целые предложения, добавляя информацию о том, как, когда, где, почему или в какой степени что-то происходит.</p>
+          <p><strong>Примеры:</strong> quickly, very, always, well, here, yesterday, extremely</p>
+          
+          <h3>🔹 Вопросы, на которые отвечают наречия</h3>
+          
+          <h4>❓ How? (Как?)</h4>
+          <p>Наречия образа действия</p>
+          <p><strong>Примеры:</strong> quickly, carefully, loudly</p>
+          
+          <h4>⏰ When? (Когда?)</h4>
+          <p>Наречия времени</p>
+          <p><strong>Примеры:</strong> yesterday, soon, always, never</p>
+          
+          <h4>📍 Where? (Где?)</h4>
+          <p>Наречия места</p>
+          <p><strong>Примеры:</strong> here, there, everywhere, inside</p>
+          
+          <h4>🔄 How often? (Как часто?)</h4>
+          <p>Наречия частотности</p>
+          <p><strong>Примеры:</strong> always, usually, sometimes, rarely</p>
+          
+          <h4>📊 To what extent? (В какой степени?)</h4>
+          <p>Наречия степени</p>
+          <p><strong>Примеры:</strong> very, extremely, quite, too</p>
+          
+          <h3>🎯 Примеры использования в предложении</h3>
+          <ul>
+            <li>He runs <strong>quickly</strong>. (описывает глагол runs)</li>
+            <li>She is <strong>very</strong> smart. (описывает прилагательное smart)</li>
+            <li>They <strong>always</strong> arrive late. (описывает глагол arrive, наречие частотности)</li>
+            <li>He speaks <strong>well</strong>. (описывает глагол speaks, наречие образа действия)</li>
+            <li>I went <strong>there</strong> yesterday. (описывает глагол went, наречия места и времени)</li>
+          </ul>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Многие наречия образа действия образуются путем добавления -ly к прилагательному (e.g., quick → quickly).</li>
+            <li>Положение наречия в предложении может меняться в зависимости от его типа и того, что оно описывает.</li>
+            <li>Это может влиять на смысл предложения.</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Adverbs</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какое наречие описывает образ действия?</p>
+            <button class="test-btn" onclick="checkAnswer('always', 'quickly', 'here', 'quickly')">A) always</button>
+            <button class="test-btn" onclick="checkAnswer('always', 'quickly', 'here', 'quickly')">B) quickly</button>
+            <button class="test-btn" onclick="checkAnswer('always', 'quickly', 'here', 'quickly')">C) here</button>
+            <button class="test-btn" onclick="checkAnswer('always', 'quickly', 'here', 'quickly')">D) quickly</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какое наречие является наречием времени?</p>
+            <button class="test-btn" onclick="checkAnswer('very', 'yesterday', 'everywhere', 'yesterday')">A) very</button>
+            <button class="test-btn" onclick="checkAnswer('very', 'yesterday', 'everywhere', 'yesterday')">B) yesterday</button>
+            <button class="test-btn" onclick="checkAnswer('very', 'yesterday', 'everywhere', 'yesterday')">C) everywhere</button>
+            <button class="test-btn" onclick="checkAnswer('very', 'yesterday', 'everywhere', 'yesterday')">D) yesterday</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Как образуются многие наречия образа действия?</p>
+            <button class="test-btn" onclick="checkAnswer('Добавлением -ly', 'Добавлением -er', 'Добавлением -est', 'Добавлением -ly')">A) Добавлением -ly</button>
+            <button class="test-btn" onclick="checkAnswer('Добавлением -ly', 'Добавлением -er', 'Добавлением -est', 'Добавлением -ly')">B) Добавлением -er</button>
+            <button class="test-btn" onclick="checkAnswer('Добавлением -ly', 'Добавлением -er', 'Добавлением -est', 'Добавлением -ly')">C) Добавлением -est</button>
+            <button class="test-btn" onclick="checkAnswer('Добавлением -ly', 'Добавлением -er', 'Добавлением -est', 'Добавлением -ly')">D) Добавлением -ly</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Prepositions -->
+    <div id="prepositions-page" class="page">
+      <div class="header">
+        <button onclick="showPage('parts-of-speech')" class="back-btn">← Назад</button>
+        <h1>🔗 Prepositions (Предлоги)</h1>
+      </div>
+
+      <div class="content">
+        <h2>Предлоги в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Определение и функция</h3>
+          <p>Небольшие слова (или группы слов), которые показывают отношение между существительным или местоимением (объектом предлога) и другими словами в предложении. Они указывают на место, время, направление, способ и т.д.</p>
+          <p><strong>Примеры:</strong> in, on, at, under, for, with, to, from, about, before, after</p>
+          
+          <h3>🎯 Примеры использования в предложении</h3>
+          <ul>
+            <li>The book is <strong>on</strong> the table. (показывает место book относительно table)</li>
+            <li>I did it <strong>for</strong> you. (показывает цель did)</li>
+            <li>He is <strong>in</strong> the house. (показывает место he)</li>
+            <li>We leave <strong>at</strong> 8 a.m. (показывает время leave)</li>
+            <li>She talked <strong>about</strong> her trip. (показывает тему talked)</li>
+          </ul>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Предлоги всегда используются с объектом (существительным, местоимением или герундием), образуя предложную фразу.</li>
+            <li>Многие глаголы, прилагательные и существительные имеют устойчивые сочетания с определенными предлогами (e.g., listen to, good at, interested in, depend on). Их нужно запоминать.</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Prepositions</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какой предлог используется для указания времени?</p>
+            <button class="test-btn" onclick="checkAnswer('in', 'at', 'on', 'at')">A) in</button>
+            <button class="test-btn" onclick="checkAnswer('in', 'at', 'on', 'at')">B) at</button>
+            <button class="test-btn" onclick="checkAnswer('in', 'at', 'on', 'at')">C) on</button>
+            <button class="test-btn" onclick="checkAnswer('in', 'at', 'on', 'at')">D) at</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какой предлог используется для указания места?</p>
+            <button class="test-btn" onclick="checkAnswer('for', 'in', 'about', 'in')">A) for</button>
+            <button class="test-btn" onclick="checkAnswer('for', 'in', 'about', 'in')">B) in</button>
+            <button class="test-btn" onclick="checkAnswer('for', 'in', 'about', 'in')">C) about</button>
+            <button class="test-btn" onclick="checkAnswer('for', 'in', 'about', 'in')">D) in</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Какой предлог используется для указания цели?</p>
+            <button class="test-btn" onclick="checkAnswer('with', 'for', 'about', 'for')">A) with</button>
+            <button class="test-btn" onclick="checkAnswer('with', 'for', 'about', 'for')">B) for</button>
+            <button class="test-btn" onclick="checkAnswer('with', 'for', 'about', 'for')">C) about</button>
+            <button class="test-btn" onclick="checkAnswer('with', 'for', 'about', 'for')">D) for</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Conjunctions -->
+    <div id="conjunctions-page" class="page">
+      <div class="header">
+        <button onclick="showPage('parts-of-speech')" class="back-btn">← Назад</button>
+        <h1>🔗 Conjunctions (Союзы)</h1>
+      </div>
+
+      <div class="content">
+        <h2>Союзы в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Определение и функция</h3>
+          <p>Соединяют слова, фразы, части предложений или целые предложения. Они устанавливают логическую связь между соединяемыми элементами.</p>
+          <p><strong>Примеры:</strong> and, but, or, because, although, while, if, so, when, before, after</p>
+          
+          <h3>🔹 Типы союзов</h3>
+          
+          <h4>🔗 Coordinating Conjunctions (сочинительные союзы)</h4>
+          <p>Соединяют грамматически равноправные элементы (слова, фразы, простые предложения). Их легко запомнить по аббревиатуре FANBOYS: For, And, Nor, But, Or, Yet, So.</p>
+          <p><strong>Примеры:</strong></p>
+          <ul>
+            <li>I like tea <strong>and</strong> coffee. (соединяет два существительных)</li>
+            <li>She is smart, <strong>but</strong> she is lazy. (соединяет два простых предложения)</li>
+          </ul>
+          
+          <h4>🔗 Subordinating Conjunctions (подчинительные союзы)</h4>
+          <p>Вводят придаточные (зависимые) предложения, которые не могут существовать самостоятельно. Они показывают отношение (причина, время, условие, уступка и т.д.) между главным и придаточным предложением.</p>
+          <p><strong>Примеры:</strong></p>
+          <ul>
+            <li>He didn't go <strong>because</strong> he was tired. (показывает причину)</li>
+            <li><strong>Although</strong> it was raining, we went for a walk. (показывает уступку)</li>
+          </ul>
+          
+          <h4>🔗 Correlative Conjunctions (соотносительные союзы)</h4>
+          <p>Работают в парах, соединяя равноправные элементы.</p>
+          <p><strong>Примеры:</strong> either...or, neither...nor, not only...but also, both...and</p>
+          <ul>
+            <li><strong>Not only</strong> is he smart, <strong>but also</strong> he is kind. (Не только умный, но и добрый.)</li>
+          </ul>
+          
+          <h3>🎯 Примеры использования в предложении</h3>
+          <ul>
+            <li>I like tea <strong>and</strong> coffee.</li>
+            <li>He didn't go <strong>because</strong> he was tired.</li>
+            <li>She is smart <strong>but</strong> lazy.</li>
+            <li><strong>If</strong> you study, you'll pass the exam.</li>
+          </ul>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Правильный выбор союза помогает ясно выразить мысль и логические связи в предложении.</li>
+            <li>Пунктуация с союзами (особенно запятые) зависит от их типа и структуры предложения.</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Conjunctions</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какой союз является сочинительным?</p>
+            <button class="test-btn" onclick="checkAnswer('because', 'and', 'although', 'and')">A) because</button>
+            <button class="test-btn" onclick="checkAnswer('because', 'and', 'although', 'and')">B) and</button>
+            <button class="test-btn" onclick="checkAnswer('because', 'and', 'although', 'and')">C) although</button>
+            <button class="test-btn" onclick="checkAnswer('because', 'and', 'although', 'and')">D) and</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какой союз показывает причину?</p>
+            <button class="test-btn" onclick="checkAnswer('but', 'because', 'and', 'because')">A) but</button>
+            <button class="test-btn" onclick="checkAnswer('but', 'because', 'and', 'because')">B) because</button>
+            <button class="test-btn" onclick="checkAnswer('but', 'because', 'and', 'because')">C) and</button>
+            <button class="test-btn" onclick="checkAnswer('but', 'because', 'and', 'because')">D) because</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Какой союз показывает уступку?</p>
+            <button class="test-btn" onclick="checkAnswer('if', 'although', 'because', 'although')">A) if</button>
+            <button class="test-btn" onclick="checkAnswer('if', 'although', 'because', 'although')">B) although</button>
+            <button class="test-btn" onclick="checkAnswer('if', 'although', 'because', 'although')">C) because</button>
+            <button class="test-btn" onclick="checkAnswer('if', 'although', 'because', 'although')">D) although</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Страница Interjections -->
+    <div id="interjections-page" class="page">
+      <div class="header">
+        <button onclick="showPage('parts-of-speech')" class="back-btn">← Назад</button>
+        <h1>💬 Interjections (Междометия)</h1>
+      </div>
+
+      <div class="content">
+        <h2>Междометия в английском языке</h2>
+        
+        <div class="grammar-content">
+          <h3>📖 Определение и функция</h3>
+          <p>Слова или короткие фразы, которые выражают сильные эмоции, удивление, боль, радость, одобрение, сомнение, призыв к вниманию или являются звукоподражаниями. Они не имеют грамматической связи с другими членами предложения и часто стоят отдельно.</p>
+          <p><strong>Примеры:</strong> oh, wow, ouch, hey, hmm, hurray, oops</p>
+          
+          <h3>🎯 Примеры использования в предложении</h3>
+          <ul>
+            <li><strong>Wow!</strong> That's amazing! (выражает удивление/восхищение)</li>
+            <li><strong>Ouch!</strong> That hurt. (выражает боль)</li>
+            <li><strong>Hey,</strong> how are you? (призыв к вниманию)</li>
+            <li><strong>Hmm,</strong> I'm not sure. (выражает сомнение)</li>
+            <li><strong>Bravo!</strong> You did it! (выражает одобрение)</li>
+            <li><strong>Oops!</strong> I dropped my pen. (выражает легкую оплошность)</li>
+          </ul>
+          
+          <h3>📝 Дополнительно</h3>
+          <ul>
+            <li>Междометия не являются членами предложения (т.е. не выполняют синтаксических функций подлежащего, сказуемого и т.д.).</li>
+            <li>Могут сопровождаться восклицательным знаком (!), запятой (,) или точкой (.), в зависимости от силы выражаемой эмоции.</li>
+            <li>Их использование чаще встречается в разговорной речи и неформальном письме.</li>
+          </ul>
+        </div>
+        
+        <div class="test-section">
+          <h3>🧪 Тест: Interjections</h3>
+          <div class="test-question">
+            <p><strong>Вопрос 1:</strong> Какое междометие выражает боль?</p>
+            <button class="test-btn" onclick="checkAnswer('Wow', 'Ouch', 'Hey', 'Ouch')">A) Wow</button>
+            <button class="test-btn" onclick="checkAnswer('Wow', 'Ouch', 'Hey', 'Ouch')">B) Ouch</button>
+            <button class="test-btn" onclick="checkAnswer('Wow', 'Ouch', 'Hey', 'Ouch')">C) Hey</button>
+            <button class="test-btn" onclick="checkAnswer('Wow', 'Ouch', 'Hey', 'Ouch')">D) Ouch</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 2:</strong> Какое междометие выражает удивление?</p>
+            <button class="test-btn" onclick="checkAnswer('Hmm', 'Wow', 'Oops', 'Wow')">A) Hmm</button>
+            <button class="test-btn" onclick="checkAnswer('Hmm', 'Wow', 'Oops', 'Wow')">B) Wow</button>
+            <button class="test-btn" onclick="checkAnswer('Hmm', 'Wow', 'Oops', 'Wow')">C) Oops</button>
+            <button class="test-btn" onclick="checkAnswer('Hmm', 'Wow', 'Oops', 'Wow')">D) Wow</button>
+          </div>
+          
+          <div class="test-question">
+            <p><strong>Вопрос 3:</strong> Какое междометие является призывом к вниманию?</p>
+            <button class="test-btn" onclick="checkAnswer('Hey', 'Ouch', 'Hmm', 'Hey')">A) Hey</button>
+            <button class="test-btn" onclick="checkAnswer('Hey', 'Ouch', 'Hmm', 'Hey')">B) Ouch</button>
+            <button class="test-btn" onclick="checkAnswer('Hey', 'Ouch', 'Hmm', 'Hey')">C) Hmm</button>
+            <button class="test-btn" onclick="checkAnswer('Hey', 'Ouch', 'Hmm', 'Hey')">D) Hey</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Вставка: Подстраницы тематических слов -->
+    <div id="family-words-page" class="page">
+      <div class="header">
+        <button onclick="showPage('topics')" class="back-btn">← Назад</button>
+        <h1>👨‍👩‍👧‍👦 Семья</h1>
+      </div>
+      <div class="content">
+        <div class="grammar-content">
+          <div class="word-card"><h4>mother — мама</h4><p>My mother is a teacher.</p></div>
+          <div class="word-card"><h4>father — отец</h4><p>His father works at a bank.</p></div>
+          <div class="word-card"><h4>sibling — брат/сестра</h4><p>She has two siblings.</p></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="work-words-page" class="page">
+      <div class="header">
+        <button onclick="showPage('topics')" class="back-btn">← Назад</button>
+        <h1>💼 Работа</h1>
+      </div>
+      <div class="content">
+        <div class="grammar-content">
+          <div class="word-card"><h4>employee — сотрудник</h4><p>Our company has 100 employees.</p></div>
+          <div class="word-card"><h4>salary — зарплата</h4><p>He gets his salary every month.</p></div>
+          <div class="word-card"><h4>meeting — встреча</h4><p>The meeting starts at 10 a.m.</p></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="food-words-page" class="page">
+      <div class="header">
+        <button onclick="showPage('topics')" class="back-btn">← Назад</button>
+        <h1>🍕 Еда</h1>
+      </div>
+      <div class="content">
+        <div class="grammar-content">
+          <div class="word-card"><h4>vegetables — овощи</h4><p>Vegetables are healthy.</p></div>
+          <div class="word-card"><h4>fruit — фрукты</h4><p>She likes fresh fruit.</p></div>
+          <div class="word-card"><h4>dish — блюдо</h4><p>This is my favorite dish.</p></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="travel-words-page" class="page">
+      <div class="header">
+        <button onclick="showPage('topics')" class="back-btn">← Назад</button>
+        <h1>✈️ Путешествия</h1>
+      </div>
+      <div class="content">
+        <div class="grammar-content">
+          <div class="word-card"><h4>ticket — билет</h4><p>I bought a plane ticket.</p></div>
+          <div class="word-card"><h4>luggage — багаж</h4><p>Don't forget your luggage.</p></div>
+          <div class="word-card"><h4>hotel — отель</h4><p>We booked a hotel near the beach.</p></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Идиомы -->
+    <div id="idioms-page" class="page">
+      <div class="header">
+        <button onclick="showPage('vocabulary')" class="back-btn">← Назад</button>
+        <h1>💬 Идиомы</h1>
+      </div>
+      <div class="content">
+        <div class="grammar-content">
+          <div class="word-card"><h4>break the ice — растопить лёд</h4><p>He told a joke to break the ice.</p></div>
+          <div class="word-card"><h4>once in a blue moon — очень редко</h4><p>We see each other once in a blue moon.</p></div>
+          <div class="word-card"><h4>piece of cake — проще простого</h4><p>The test was a piece of cake.</p></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Фразовые глаголы -->
+    <div id="phrasal-verbs-page" class="page">
+      <div class="header">
+        <button onclick="showPage('vocabulary')" class="back-btn">← Назад</button>
+        <h1>🔗 Фразовые глаголы</h1>
+      </div>
+      <div class="content">
+        <div class="grammar-content">
+          <div class="word-card"><h4>look up — искать (в словаре)</h4><p>Look up the word in the dictionary.</p></div>
+          <div class="word-card"><h4>give up — сдаваться</h4><p>Don't give up!</p></div>
+          <div class="word-card"><h4>pick up — подбирать; подхватывать</h4><p>I will pick you up at 7.</p></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Конец вставки -->
   </div>
 
   <script>
@@ -2065,6 +3774,48 @@
     }
 
     // SPA навигация с историей браузера
+
+    // Источник слов на каждый день. Можно свободно дополнять.
+    const dailyWords = [
+      { emoji: '🌟', word: 'Accomplish', ru: 'достигать, выполнять', enExample: 'She accomplished her goal of learning English.', ruExample: 'Она достигла своей цели изучения английского.' },
+      { emoji: '💡', word: 'Perseverance', ru: 'настойчивость, упорство', enExample: 'His perseverance helped him succeed.', ruExample: 'Его настойчивость помогла ему добиться успеха.' },
+      { emoji: '🚀', word: 'Endeavor', ru: 'стремление, попытка', enExample: 'Learning a new language is a worthwhile endeavor.', ruExample: 'Изучение нового языка — стоящее стремление.' },
+      { emoji: '🧭', word: 'Aspire', ru: 'стремиться', enExample: 'Many students aspire to study abroad.', ruExample: 'Многие студенты стремятся учиться за рубежом.' },
+      { emoji: '🔥', word: 'Commitment', ru: 'приверженность, обязательство', enExample: 'Success requires commitment and hard work.', ruExample: 'Успех требует приверженности и усердной работы.' }
+    ];
+
+    function formatDateRu(date){
+      const options = { day: 'numeric', month: 'long', year: 'numeric' };
+      return date.toLocaleDateString('ru-RU', options);
+    }
+
+    function getDailyIndex(date){
+      const start = new Date('2025-01-01T00:00:00Z');
+      const diffDays = Math.floor((Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) - Date.UTC(start.getFullYear(), start.getMonth(), start.getDate())) / 86400000);
+      const len = dailyWords.length || 1;
+      return ((diffDays % len) + len) % len;
+    }
+
+    function renderDailyWord(){
+      const today = new Date();
+      const dateEl = document.getElementById('daily-words-date');
+      if (dateEl){
+        dateEl.textContent = 'Слова дня - ' + formatDateRu(today);
+      }
+      const container = document.getElementById('daily-word-container');
+      if (!container) return;
+      const item = dailyWords[getDailyIndex(today)];
+      container.innerHTML = `
+        <h3>🎯 Сегодняшнее слово</h3>
+        <div class="word-card">
+          <h4>${item.emoji} ${item.word}</h4>
+          <p><strong>Перевод:</strong> ${item.ru}</p>
+          <p><strong>Пример:</strong> ${item.enExample}</p>
+          <p><em>${item.ruExample}</em></p>
+        </div>
+      `;
+    }
+
     const pageHistory = [];
     function setActivePage(pageName, push = true){
       // Sanitize and provide robust fallback for Telegram hashes
@@ -2087,6 +3838,11 @@
       if (push){
         pageHistory.push(targetPage);
         history.pushState({pageName: targetPage}, '', '#' + targetPage);
+      }
+
+      // Доп. хуки для страниц
+      if (targetPage === 'daily-words') {
+        renderDailyWord();
       }
 
       // Make sure nav buttons exist on the newly shown page header as well
@@ -2116,13 +3872,16 @@
       setActivePage(prev, false);
     };
     // Инициализация стартовой страницы из hash/по умолчанию
-    (function initRouting(){
+    (    function initRouting(){
       let initial = (location.hash || '#main').toString();
       try {
         // Telegram sometimes provides empty or malformed hash
         initial = initial.replace(/^#?/, '#');
         const clean = initial.replace('#','').trim();
         setActivePage(clean || 'main', true);
+        if ((clean || 'main') === 'daily-words') {
+          renderDailyWord();
+        }
       } catch (e) {
         console.warn('Init routing failed, fallback to main:', e);
         setActivePage('main', true);
@@ -2190,7 +3949,14 @@
 
     function openSection(section) {
       console.log('Opening section:', section);
-      alert(`Открывается раздел: ${section}`);
+      const map = {
+        'daily_words': 'daily-words',
+        'topics': 'topics',
+        'idioms': 'idioms',
+        'phrasal_verbs': 'phrasal-verbs'
+      };
+      const target = map[section] || section;
+      setActivePage(target, true);
     }
 
     function testAlert() {

--- a/style.css
+++ b/style.css
@@ -530,3 +530,5 @@ body, .page, .content, #grammar-page, #grammar-page .content, .detail-box {
   letter-spacing: 0.2px;
   font-weight: 600;
 }
+
+#daily-word-container .word-card { margin-top: 12px; }

--- a/vocabulary.html
+++ b/vocabulary.html
@@ -75,7 +75,14 @@
     
     function openSection(section) {
       console.log('Opening section:', section);
-      alert(`Открывается раздел: ${section}`);
+      const map = {
+        'daily_words': 'daily-words',
+        'topics': 'topics',
+        'idioms': 'idioms',
+        'phrasal_verbs': 'phrasal-verbs'
+      };
+      const target = map[section] || section;
+      window.location.href = 'index.html#' + target;
     }
   </script>
 </body>


### PR DESCRIPTION
Implement dynamic 'Word of the Day' and fix navigation for 'Thematic Words', 'Idioms', and 'Phrasal Verbs' to open dedicated pages.

Previously, 'Word of the Day' displayed a static list, and selecting sub-sections under 'Vocabulary' incorrectly redirected to the main menu due to missing pages and incorrect routing logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2d6d157-3d1e-40d0-b1bf-c2fe740efcd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2d6d157-3d1e-40d0-b1bf-c2fe740efcd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

