### PR TITLE
Fix back button navigation in vocabulary

### DIFF
--- a/index.html
+++ b/index.html
@@ -3658,7 +3658,7 @@
     <!-- Вставка: Подстраницы тематических слов -->
     <div id="family-words-page" class="page">
       <div class="header">
-        <button onclick="showPage('topics')" class="back-btn">← Назад</button>
+        <button onclick="goBack()" class="back-btn">← Назад</button>
         <h1>👨‍👩‍👧‍👦 Семья</h1>
       </div>
       <div class="content">
@@ -3689,7 +3689,7 @@
 
     <div id="work-words-page" class="page">
       <div class="header">
-        <button onclick="showPage('topics')" class="back-btn">← Назад</button>
+        <button onclick="goBack()" class="back-btn">← Назад</button>
         <h1>💼 Работа</h1>
       </div>
       <div class="content">
@@ -3720,7 +3720,7 @@
 
     <div id="food-words-page" class="page">
       <div class="header">
-        <button onclick="showPage('topics')" class="back-btn">← Назад</button>
+        <button onclick="goBack()" class="back-btn">← Назад</button>
         <h1>🍕 Еда</h1>
       </div>
       <div class="content">
@@ -3751,7 +3751,7 @@
 
     <div id="travel-words-page" class="page">
       <div class="header">
-        <button onclick="showPage('topics')" class="back-btn">← Назад</button>
+        <button onclick="goBack()" class="back-btn">← Назад</button>
         <h1>✈️ Путешествия</h1>
       </div>
       <div class="content">


### PR DESCRIPTION
Fixes back button looping on vocabulary sub-pages by using `goBack()` instead of `showPage()`.

Previously, the back button on pages like 'Семья' would call `showPage('topics')`, which added a new entry to the browser history, causing a loop where pressing back again would return to the sub-page instead of navigating further up the history stack. Changing to `goBack()` ensures correct hierarchical navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-216b3216-37af-4ec5-bcdd-35eb90bf628a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-216b3216-37af-4ec5-bcdd-35eb90bf628a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

