### PR TITLE
Fix back button navigation in vocabulary sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -3783,7 +3783,7 @@
     <!-- Идиомы -->
     <div id="idioms-page" class="page">
       <div class="header">
-        <button onclick="showPage('vocabulary')" class="back-btn">← Назад</button>
+        <button onclick="goBack()" class="back-btn">← Назад</button>
         <h1>💬 Идиомы</h1>
       </div>
       <div class="content">
@@ -3798,7 +3798,7 @@
     <!-- Фразовые глаголы -->
     <div id="phrasal-verbs-page" class="page">
       <div class="header">
-        <button onclick="showPage('vocabulary')" class="back-btn">← Назад</button>
+        <button onclick="goBack()" class="back-btn">← Назад</button>
         <h1>🔗 Фразовые глаголы</h1>
       </div>
       <div class="content">
@@ -3813,7 +3813,7 @@
     <!-- Word Formation -->
     <div id="word-formation-page" class="page">
       <div class="header">
-        <button onclick="showPage('vocabulary')" class="back-btn">← Назад</button>
+        <button onclick="goBack()" class="back-btn">← Назад</button>
         <h1>🧩 Word Formation</h1>
       </div>
       <div class="content">


### PR DESCRIPTION
Update back button logic for Idioms, Phrasal Verbs, and Word Formation to ensure correct hierarchical navigation.

The previous implementation used `showPage('vocabulary')`, which added a new entry to the browser history, preventing a direct return to the main page after navigating back from a sub-section. Switching to `goBack()` ensures the history is popped correctly, allowing a proper multi-level back navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-c07799b4-1f26-4ba5-b49b-1407a798ec3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c07799b4-1f26-4ba5-b49b-1407a798ec3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

