### PR TITLE
Fix test json for response column

### DIFF
--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -52,7 +52,7 @@ def create_user_lesson_task(cur):
 
 def insert_attempt(cur, user_id, task_id, is_correct):
     cur.execute(
-        "INSERT INTO task_attempt (user_id, task_id, is_correct, response) VALUES (%s, %s, %s, '{"r":1}'::jsonb) RETURNING id",
+        "INSERT INTO task_attempt (user_id, task_id, is_correct, response) VALUES (%s, %s, %s, '{}'::jsonb) RETURNING id",
         (user_id, task_id, is_correct),
     )
     return cur.fetchone()[0]


### PR DESCRIPTION
Fix tests by replacing an invalid JSON literal in the `insert_attempt` helper to prevent PostgreSQL parse errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-86faca76-cd48-47b6-af95-d2c685d5f058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86faca76-cd48-47b6-af95-d2c685d5f058">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

