### PR TITLE
Add manual prod migration github action

### DIFF
--- a/.github/workflows/migrate-prod.yml
+++ b/.github/workflows/migrate-prod.yml
@@ -1,0 +1,45 @@
+name: Migrate PROD
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Show alembic heads/current before upgrade"
+        required: false
+        default: "false"
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      # (optional) quick visibility before applying
+      - name: Alembic info (dry-run)
+        if: ${{ inputs.dry_run == 'true' }}
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+        run: |
+          alembic --version
+          alembic heads
+          alembic current || true
+
+      - name: Upgrade DB
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+        run: alembic upgrade head
+
+      - name: Show current revision
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+        run: alembic current
+


### PR DESCRIPTION
Add a manual "Migrate PROD" GitHub Action to apply Alembic migrations to the Railway Postgres database.

---
<a href="https://cursor.com/background-agent?bcId=bc-04d4e1c5-f0d8-454f-922a-c028f75e9d91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04d4e1c5-f0d8-454f-922a-c028f75e9d91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

