### PR TITLE
Исправить отображение разделов грамматики и лексики

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional, List
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, FileResponse
+from fastapi.responses import JSONResponse, FileResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 import logging
@@ -277,6 +277,17 @@ def root():
     if os.path.exists(index_path):
         return FileResponse(index_path)
     return {"ok": True}
+
+
+# Friendly redirects for legacy sections so links like /grammar work
+@app.get("/grammar")
+def grammar_legacy_redirect():
+    return RedirectResponse(url="/legacy/grammar.html")
+
+
+@app.get("/vocabulary")
+def vocabulary_legacy_redirect():
+    return RedirectResponse(url="/legacy/vocabulary.html")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add redirects for `/grammar` and `/vocabulary` to their respective legacy HTML pages.

This fixes the "Not Found" error when accessing these routes directly and ensures the correct loading of `grammar_categories_tree.json` for displaying categories.

---
<a href="https://cursor.com/background-agent?bcId=bc-7976035f-8cdf-4f5b-9c21-9b69123db285">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7976035f-8cdf-4f5b-9c21-9b69123db285">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

