### PR TITLE
Implement free/pro model and fix grammar route

### DIFF
--- a/alembic/versions/20250828_user_plan.py
+++ b/alembic/versions/20250828_user_plan.py
@@ -1,0 +1,40 @@
+"""add user plan and entitlements
+
+Revision ID: user_plan_001
+Revises: 0002
+Create Date: 2025-08-28 00:00:00
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "user_plan_001"
+down_revision = "0002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("app_user", sa.Column("plan", sa.String(length=16), nullable=False, server_default="free"))
+    op.add_column("app_user", sa.Column("pro_until", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "app_user",
+        sa.Column(
+            "entitlements",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("app_user", "entitlements")
+    op.drop_column("app_user", "pro_until")
+    op.drop_column("app_user", "plan")
+

--- a/static/index.html
+++ b/static/index.html
@@ -70,6 +70,8 @@
     const tg = window.Telegram?.WebApp;
     let state = {
       userId: null,
+      plan: 'free',
+      entitlements: {},
       group: 'grammar',
       lessons: [],
       currentLesson: null,
@@ -82,6 +84,27 @@
     const $authStatus = document.getElementById('authStatus');
     const $tabs = document.querySelectorAll('.tab');
 
+    function hasEnt(key){
+      if (state.plan === 'pro') return true;
+      return !!(state.entitlements && state.entitlements[key] === true);
+    }
+
+    function applyGating(){
+      document.querySelectorAll('[data-pro-only]').forEach(el => {
+        const key = el.getAttribute('data-pro-only');
+        const enabled = (state.plan === 'pro') || (state.entitlements && state.entitlements[key] === true);
+        el.classList.toggle('disabled', !enabled);
+        const handler = (e) => {
+          if (!enabled){
+            e.preventDefault();
+            alert('Эта функция доступна в Pro.');
+            return false;
+          }
+        };
+        el.addEventListener('click', handler);
+      });
+    }
+
     async function ensureUser() {
       const tgId = tg?.initDataUnsafe?.user?.id || null;
       if (tgId) {
@@ -91,8 +114,11 @@
         });
         const data = await resp.json();
         state.userId = data.user_id;
+        state.plan = data.plan || 'free';
+        state.entitlements = data.entitlements || {};
         $authStatus.textContent = `Telegram • user_id=${state.userId}`;
         tg?.ready?.();
+        applyGating();
       } else {
         state.userId = 1; // fallback для браузера
         $authStatus.textContent = 'Demo • user_id=1';


### PR DESCRIPTION
Implement Free/Pro model, fix `/lessons/overview` SQL error, add UI gating, and a legacy grammar route.

The `/lessons/overview` endpoint previously failed with psycopg errors due to unparameterized `%` characters in ILIKE clauses, causing only one lesson to be visible. This PR fixes the SQL query to correctly filter lessons by topic and emoji prefixes.

---
<a href="https://cursor.com/background-agent?bcId=bc-c508c0aa-4bc7-4cb6-a423-b1b5a36bb728">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c508c0aa-4bc7-4cb6-a423-b1b5a36bb728">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

