### PR TITLE
Fix ci tests to use in-process asgi client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest==8.2.2
 python-dotenv==1.0.1
 fastapi==0.111.0
 uvicorn[standard]==0.30.0
+httpx==0.27.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+import httpx
+from httpx import ASGITransport
+
+# Set DATABASE_URL for tests before importing the app
+os.environ.setdefault("DATABASE_URL", "postgresql+psycopg://postgres:postgres@localhost:5432/appdb")
+
+from app.main import app  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def api_client():
+    transport = ASGITransport(app=app)
+    with httpx.Client(transport=transport, base_url="http://testserver", timeout=10.0) as client:
+        yield client
+

--- a/tests/test_catalog_tree.py
+++ b/tests/test_catalog_tree.py
@@ -3,10 +3,10 @@ import time
 import uuid
 import psycopg
 import pytest
-import httpx
+ 
 
 DB_URL = os.getenv("DATABASE_URL", "postgresql+psycopg://postgres:postgres@localhost:5432/appdb")
-API_URL = os.getenv("API_URL", "http://localhost:8000")
+ 
 
 
 def pg_native_url(url: str) -> str:
@@ -45,33 +45,31 @@ def ensure_seed_tree(conn):
             cur.execute("INSERT INTO lesson (title, topic) VALUES ('Animals A1', '🧠 Animals / Mammals / Cats')")
 
 
-def test_catalog_tree_grammar(conn):
+def test_catalog_tree_grammar(conn, api_client):
     ensure_seed_tree(conn)
-    with httpx.Client(base_url=API_URL, timeout=10.0) as client:
-        r = client.get("/catalog/tree", params={"group":"grammar"})
-        assert r.status_code == 200
-        data = r.json()
-        assert data.get("group") == "grammar"
-        sections = data.get("sections", [])
-        assert isinstance(sections, list) and len(sections) > 0
-        # ensure 3-level presence
-        any_unit = False
-        for s in sections:
-            for sub in s.get("subsections", []):
-                if sub.get("units"):
-                    any_unit = True
-        assert any_unit
+    r = api_client.get("/catalog/tree", params={"group": "grammar"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("group") == "grammar"
+    sections = data.get("sections", [])
+    assert isinstance(sections, list) and len(sections) > 0
+    # ensure 3-level presence
+    any_unit = False
+    for s in sections:
+        for sub in s.get("subsections", []):
+            if sub.get("units"):
+                any_unit = True
+    assert any_unit
 
 
-def test_lessons_overview_filtering(conn):
-    with httpx.Client(base_url=API_URL, timeout=10.0) as client:
-        r = client.get("/lessons/overview", params={
-            "user_id": 1,
-            "group": "grammar",
-            "section": "Tenses",
-            "subsection": "Present"
-        })
-        assert r.status_code == 200
-        data = r.json()
-        assert data.get("group") == "grammar"
-        assert isinstance(data.get("lessons"), list)
+def test_lessons_overview_filtering(conn, api_client):
+    r = api_client.get("/lessons/overview", params={
+        "user_id": 1,
+        "group": "grammar",
+        "section": "Tenses",
+        "subsection": "Present"
+    })
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("group") == "grammar"
+    assert isinstance(data.get("lessons"), list)

--- a/tests/test_lessons_overview.py
+++ b/tests/test_lessons_overview.py
@@ -4,11 +4,11 @@ import uuid
 
 import psycopg
 import pytest
-import httpx
+ 
 
 
 DB_URL = os.getenv("DATABASE_URL", "postgresql+psycopg://postgres:postgres@localhost:5432/appdb")
-API_URL = os.getenv("API_URL", "http://localhost:8000")
+ 
 
 
 def pg_native_url(url: str) -> str:
@@ -54,30 +54,28 @@ def ensure_seed_lessons(conn):
 			cur.execute("INSERT INTO lesson (title, topic) VALUES ('V2', 'Vocab: Animals')")
 
 
-def test_lessons_overview_returns_grammar(conn):
+def test_lessons_overview_returns_grammar(conn, api_client):
 	ensure_seed_lessons(conn)
 	user_id = create_user(conn)
-	with httpx.Client(base_url=API_URL, timeout=10.0) as client:
-		r = client.get(f"/lessons/overview", params={"user_id": user_id, "group": "grammar"})
-		assert r.status_code == 200
-		data = r.json()
-		assert data.get("group") == "grammar"
-		lessons = data.get("lessons", [])
-		assert len(lessons) > 0
-		# At least one should have a grammar emoji/prefix
-		assert any(l["topic"].startswith(("📚", "📌", "🧱", "🛠", "🚫", "Grammar")) for l in lessons if l["topic"]) 
+	r = api_client.get(f"/lessons/overview", params={"user_id": user_id, "group": "grammar"})
+	assert r.status_code == 200
+	data = r.json()
+	assert data.get("group") == "grammar"
+	lessons = data.get("lessons", [])
+	assert len(lessons) > 0
+	# At least one should have a grammar emoji/prefix
+	assert any(l["topic"].startswith(("📚", "📌", "🧱", "🛠", "🚫", "Grammar")) for l in lessons if l["topic"]) 
 
 
-def test_lessons_overview_returns_vocabulary(conn):
+def test_lessons_overview_returns_vocabulary(conn, api_client):
 	ensure_seed_lessons(conn)
 	user_id = create_user(conn)
-	with httpx.Client(base_url=API_URL, timeout=10.0) as client:
-		r = client.get(f"/lessons/overview", params={"user_id": user_id, "group": "vocabulary"})
-		assert r.status_code == 200
-		data = r.json()
-		assert data.get("group") == "vocabulary"
-		lessons = data.get("lessons", [])
-		assert len(lessons) > 0
-		# At least one should have a vocabulary emoji/prefix
-		assert any(l["topic"].startswith(("🧠", "Vocabulary", "Vocab")) for l in lessons if l["topic"]) 
+	r = api_client.get(f"/lessons/overview", params={"user_id": user_id, "group": "vocabulary"})
+	assert r.status_code == 200
+	data = r.json()
+	assert data.get("group") == "vocabulary"
+	lessons = data.get("lessons", [])
+	assert len(lessons) > 0
+	# At least one should have a vocabulary emoji/prefix
+	assert any(l["topic"].startswith(("🧠", "Vocabulary", "Vocab")) for l in lessons if l["topic"]) 
 


### PR DESCRIPTION
Switch CI tests to use an in-process ASGI client to resolve `httpx.ConnectError` caused by missing `uvicorn` server.

The CI environment runs `pytest` without an active `uvicorn` server, causing tests that relied on `API_URL` to fail with `Connection refused` errors. This change refactors these tests to use `httpx.ASGITransport`, which allows direct interaction with the FastAPI application instance, bypassing network requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-46b738e1-c0df-4b21-a3f3-c27db2db2261">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46b738e1-c0df-4b21-a3f3-c27db2db2261">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

