### PR TITLE
Fix failing migration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 import httpx
 from httpx import ASGITransport
@@ -6,6 +7,11 @@ from httpx import ASGITransport
 # Set DATABASE_URL for tests before importing the app
 os.environ.setdefault("DATABASE_URL", "postgresql+psycopg://postgres:postgres@localhost:5432/appdb")
 os.environ.setdefault("ADMIN_TOKEN", "test_admin_token")
+
+# Ensure repository root is importable so the `app` package resolves in CI
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
 
 from app.main import app  # noqa: E402
 


### PR DESCRIPTION
Add repository root to `sys.path` in `tests/conftest.py` to resolve `ModuleNotFoundError` during CI tests.

The CI workflow showed a failure during the "DB & Tests" step. Although the user reported a failing migration, the actual error was `ModuleNotFoundError: No module named 'app'` when tests tried to import `app.main`. This change ensures the `app` package is discoverable, allowing tests to run correctly and preventing the false impression of a migration failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c1e2fdb-ccc5-4d7a-abb7-4f509e5e5089">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c1e2fdb-ccc5-4d7a-abb7-4f509e5e5089">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

